### PR TITLE
fix: add contents and id-token write permissions for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write   # create GitHub releases/tags (autorel)
+      id-token: write  # npm trusted publishing (OIDC)
     concurrency:
       group: release-${{github.ref}}
       cancel-in-progress: true


### PR DESCRIPTION
Add `contents: write` (GitHub releases/tags) and `id-token: write` (npm trusted publishing OIDC) so the release job can complete.