### PR TITLE
fix: use npm OIDC only for release; pin autorel to ^2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,5 +32,4 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-        run: npx autorel --publish
+        run: npx autorel@^2 --publish


### PR DESCRIPTION
Remove NODE_AUTH_TOKEN from release step (use trusted publishing OIDC only). Pin `npx autorel@^2` for reproducible releases.