### PR TITLE
fix: Node 24 + registry-url for npm 11 OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,8 @@ jobs:
           fetch-tags: true
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
-          registry-url: "https://registry.npmjs.org"
+          node-version: 24  # npm 11+ required for trusted publishing (OIDC)
+          registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Bump setup-node to Node 24 (npm 11+ required for trusted publishing). Restore registry-url and cache.