### PR TITLE
feat: add list-stacks command and SDK; refresh README copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ CLI and TypeScript SDK for managing AWS CloudFormation stacks.
 ## Why awscfn?
 
 - **Simple YAML parameters** — No more wrestling with verbose JSON. Just clean, readable YAML files.
-- **See what's happening** — Real-time event streaming shows you exactly what CloudFormation is doing instead of waiting blindly.
+- **See what's happening** — Real-time event streaming in your terminal. No refreshing the console, no juggling `aws cloudformation create-stack` and `describe-stack-events` in another window.
 - **Errors that make sense** — When deploys fail, you get the actual error message from CloudFormation, not a cryptic timeout.
 - **CI/CD friendly** — Works great in GitHub Actions with auto-detected CI mode.
 - **CLI & SDK** — Use from command line or import directly in Node.js/TypeScript projects.
@@ -56,6 +56,16 @@ During stack operations, awscfn streams CloudFormation stack events in real-time
 ```
 
 When a failure occurs, the error message includes the actual reason from CloudFormation events.
+
+### 📋 list-stacks
+
+List all CloudFormation stacks in the current region (name, status, creation date).
+
+```bash
+npx awscfn list-stacks
+```
+
+No options. Output is a table of stack name, status, and creation date.
 
 ### 🚀 create-stack
 
@@ -128,6 +138,19 @@ If the names don't match, the deletion will be aborted.
 ## API Reference
 
 > ⚠️ Requires AWS credentials to be configured in your shell or environment. [Start here](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html) if you haven't already.
+
+### 📋 `listStacks(): Promise<StackSummary[]>`
+
+Returns all CloudFormation stacks in the current region (paginated). Excludes `DELETE_COMPLETE` (AWS default). Each item is an AWS SDK `StackSummary` (e.g. `StackName`, `StackStatus`, `CreationTime`).
+
+```ts
+import { listStacks } from 'awscfn';
+
+const stacks = await listStacks();
+for (const s of stacks) {
+  console.log(s.StackName, s.StackStatus);
+}
+```
 
 ### 📦 `createStack(stackName: string, template: Template<P>): Promise<Stack>`
 

--- a/bin/awscfn
+++ b/bin/awscfn
@@ -6,6 +6,7 @@ const yargs = require('yargs');
 
 const { createStack } = require('../dist/createStack');
 const { deleteStack } = require('../dist/deleteStack');
+const { listStacks } = require('../dist/listStacks');
 const { redeployStack } = require('../dist/redeployStack');
 const { updateStack } = require('../dist/updateStack');
 const { setOutputConfig } = require('../dist/lib/output');
@@ -109,6 +110,14 @@ yargs
       color: !argv.noColor && (process.stdout.isTTY || argv.ci),
     });
   })
+  .command(
+    'list-stacks',
+    'List all CloudFormation stacks',
+    (cmd) => cmd,
+    () => {
+      runCommand(() => listStacks());
+    }
+  )
   .command(
     'create-stack',
     'Create a CloudFormation stack',

--- a/src/lib/cfn/index.ts
+++ b/src/lib/cfn/index.ts
@@ -24,6 +24,7 @@ export function getCfClient(): CloudFormationClient {
 
 export * from './createStack';
 export * from './getStackByName';
+export * from './listStacks';
 export * from './updateStack';
 export * from './deleteStack';
 export * from './validateTemplate';

--- a/src/lib/cfn/listStacks.ts
+++ b/src/lib/cfn/listStacks.ts
@@ -1,0 +1,25 @@
+import {ListStacksCommand, StackSummary} from '@aws-sdk/client-cloudformation';
+import {getCfClient} from '.';
+
+/**
+ * Fetches all CloudFormation stacks (paginated). Excludes DELETE_COMPLETE by default (AWS behavior).
+ */
+export async function listStacks(): Promise<StackSummary[]> {
+
+    const cf = getCfClient();
+    const out: StackSummary[] = [];
+    let nextToken: string | undefined;
+
+    do {
+
+        const result = await cf.send(new ListStacksCommand({NextToken: nextToken}));
+        const summaries = result.StackSummaries ?? [];
+
+        out.push(...summaries);
+        nextToken = result.NextToken;
+
+    } while (nextToken);
+
+    return out;
+
+}

--- a/src/listStacks.ts
+++ b/src/listStacks.ts
@@ -1,0 +1,47 @@
+import * as cfn from './lib/cfn';
+import {getOutputConfig, colorize} from './lib/output';
+
+const colors = {
+    dim: '\x1b[2m',
+    gray: '\x1b[90m',
+    reset: '\x1b[0m',
+};
+
+/**
+ * CLI handler: list all CloudFormation stacks.
+ */
+export async function listStacks(): Promise<void> {
+
+    cfn.initCloudFormationClient();
+
+    const stacks = await cfn.listStacks();
+    const config = getOutputConfig();
+
+    if (stacks.length === 0) {
+
+        console.log('No stacks found.');
+        return;
+
+    }
+
+    const maxName = Math.max(20, ...stacks.map((s) => (s.StackName ?? '').length));
+    const headerName = 'STACK NAME'.padEnd(maxName);
+    const headerStatus = 'STATUS';
+    const headerCreated = 'CREATED';
+
+    console.log(config.color ? colorize(`${headerName}  ${headerStatus}  ${headerCreated}`, colors.dim) : `${headerName}  ${headerStatus}  ${headerCreated}`);
+    console.log(config.color ? colorize('-'.repeat(headerName.length + 2 + headerStatus.length + 2 + 10), colors.gray) : '-'.repeat(headerName.length + 2 + headerStatus.length + 2 + 10));
+
+    for (const s of stacks) {
+
+        const name = (s.StackName ?? '—').padEnd(maxName);
+        const status = s.StackStatus ?? '—';
+        const created = s.CreationTime
+            ? s.CreationTime.toISOString().slice(0, 10)
+            : '—';
+
+        console.log(`${name}  ${status}  ${created}`);
+
+    }
+
+}


### PR DESCRIPTION
**list-stacks**
- CLI: `npx awscfn list-stacks` — table of all stacks (name, status, created)
- SDK: `listStacks(): Promise<StackSummary[]>` — paginated, excludes DELETE_COMPLETE

**README**
- Event streaming bullet: contrast with console refresh / juggling `create-stack` and `describe-stack-events`
- Docs for list-stacks (CLI + API)