### PR TITLE
feat: list-stacks + filter deleted, less noise (no redundant CLI line, error details only with -V)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ CLI and TypeScript SDK for managing AWS CloudFormation stacks.
 |------|-------|-------------|
 | `--ci` | — | CI mode (compact output). Auto-detected when `CI=true` or `GITHUB_ACTIONS=true`. Colors stay on in CI (e.g. GitHub Actions supports ANSI). |
 | `--no-color` | `-N` | Disable colored output |
+| `--verbose` | `-V` | Show full error details (e.g. `err.data` JSON) on failure |
 | `--help` | `-h` | Show help |
 | `--version` | `-v` | Show version |
 
@@ -141,7 +142,7 @@ If the names don't match, the deletion will be aborted.
 
 ### 📋 `listStacks(): Promise<StackSummary[]>`
 
-Returns all CloudFormation stacks in the current region (paginated). Excludes `DELETE_COMPLETE` (AWS default). Each item is an AWS SDK `StackSummary` (e.g. `StackName`, `StackStatus`, `CreationTime`).
+Returns all CloudFormation stacks in the current region (paginated). Excludes deleted stacks (`DELETE_COMPLETE`, `DELETE_IN_PROGRESS`) via `StackStatusFilter`. Each item is an AWS SDK `StackSummary` (e.g. `StackName`, `StackStatus`, `CreationTime`).
 
 ```ts
 import { listStacks } from 'awscfn';

--- a/bin/awscfn
+++ b/bin/awscfn
@@ -9,7 +9,7 @@ const { deleteStack } = require('../dist/deleteStack');
 const { listStacks } = require('../dist/listStacks');
 const { redeployStack } = require('../dist/redeployStack');
 const { updateStack } = require('../dist/updateStack');
-const { setOutputConfig } = require('../dist/lib/output');
+const { getOutputConfig, setOutputConfig } = require('../dist/lib/output');
 
 const pkg = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf8'));
 const isCI = process.env.CI === 'true' || process.env.GITHUB_ACTIONS === 'true';
@@ -74,7 +74,9 @@ async function runCommand(fn) {
     if (message !== err.message) {
       console.log(`\x1b[90m(original: ${err.message})\x1b[0m`);
     }
-    logErrorDetails(err.data);
+    if (getOutputConfig().verbose) {
+      logErrorDetails(err.data);
+    }
     process.exit(1);
   }
 }
@@ -104,10 +106,17 @@ yargs
     description: 'Disable colored output',
     default: false,
   })
+  .option('verbose', {
+    type: 'boolean',
+    alias: 'V',
+    description: 'Show full error details (e.g. err.data JSON) on failure',
+    default: false,
+  })
   .middleware((argv) => {
     setOutputConfig({
       ci: argv.ci,
       color: !argv.noColor && (process.stdout.isTTY || argv.ci),
+      verbose: argv.verbose,
     });
   })
   .command(
@@ -123,7 +132,6 @@ yargs
     'Create a CloudFormation stack',
     (cmd) => cmd.options({ ...nameOpt, ...templateOpt, ...paramsOpt }),
     ({ name, template, params }) => {
-      console.log(`Creating stack: ${name}...`);
       runCommand(() => createStack(name, template, params));
     }
   )
@@ -132,7 +140,6 @@ yargs
     'Delete a CloudFormation stack',
     (cmd) => cmd.options({ ...nameOpt, ...confirmOpt }),
     ({ name, confirm }) => {
-      console.log(`Deleting stack: ${name}...`);
       runCommand(() => deleteStack(name, confirm));
     }
   )
@@ -141,7 +148,6 @@ yargs
     'Redeploy a CloudFormation stack (uses existing params)',
     (cmd) => cmd.options({ ...nameOpt, ...templateOpt }),
     ({ name, template }) => {
-      console.log(`Redeploying stack: ${name}...`);
       runCommand(() => redeployStack(name, template));
     }
   )
@@ -150,7 +156,6 @@ yargs
     'Update a CloudFormation stack',
     (cmd) => cmd.options({ ...nameOpt, ...templateOpt, ...paramsOpt }),
     ({ name, template, params }) => {
-      console.log(`Updating stack: ${name}...`);
       runCommand(() => updateStack(name, template, params));
     }
   )

--- a/src/lib/cfn/listStacks.ts
+++ b/src/lib/cfn/listStacks.ts
@@ -1,8 +1,13 @@
-import {ListStacksCommand, StackSummary} from '@aws-sdk/client-cloudformation';
+import {ListStacksCommand, StackStatus, StackSummary} from '@aws-sdk/client-cloudformation';
 import {getCfClient} from '.';
 
+/** All stack statuses except deleted (DELETE_COMPLETE, DELETE_IN_PROGRESS). */
+const ACTIVE_STATUS_FILTER: StackStatus[] = (Object.values(StackStatus) as StackStatus[]).filter(
+    (s) => s !== StackStatus.DELETE_COMPLETE && s !== StackStatus.DELETE_IN_PROGRESS,
+);
+
 /**
- * Fetches all CloudFormation stacks (paginated). Excludes DELETE_COMPLETE by default (AWS behavior).
+ * Fetches all CloudFormation stacks (paginated). Excludes deleted stacks (DELETE_COMPLETE, DELETE_IN_PROGRESS).
  */
 export async function listStacks(): Promise<StackSummary[]> {
 
@@ -12,7 +17,10 @@ export async function listStacks(): Promise<StackSummary[]> {
 
     do {
 
-        const result = await cf.send(new ListStacksCommand({NextToken: nextToken}));
+        const result = await cf.send(new ListStacksCommand({
+            NextToken: nextToken,
+            StackStatusFilter: ACTIVE_STATUS_FILTER,
+        }));
         const summaries = result.StackSummaries ?? [];
 
         out.push(...summaries);


### PR DESCRIPTION
**list-stacks**
- Filter out deleted stacks (DELETE_COMPLETE, DELETE_IN_PROGRESS) via StackStatusFilter
- README: document filter

**CLI output**
- Remove redundant first line ("Creating stack: x..." / "Updating stack: x...") — lib already prints "→ Creating/Updating stack x"
- Error details (big err.data JSON) only when `--verbose` / `-V` is passed; default is clean one-line error + optional AWS hint