### PR TITLE
fix: request CAPABILITY_AUTO_EXPAND for nested stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,10 @@ If the names don't match, the deletion will be aborted.
 
 > ⚠️ Requires AWS credentials to be configured in your shell or environment. [Start here](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html) if you haven't already.
 
+### Nested stacks and IAM
+
+Change sets request **`CAPABILITY_NAMED_IAM`** and **`CAPABILITY_AUTO_EXPAND`**, so stacks that define named IAM resources or **nested stacks** (including templates from [`aws cloudformation package`](https://docs.aws.amazon.com/cli/latest/reference/cloudformation/package.html)) work with **`create-stack`** / **`update-stack`** and the SDK `createStack` / `updateStack` helpers.
+
 ### 📋 `listStacks(): Promise<StackSummary[]>`
 
 Returns all CloudFormation stacks in the current region (paginated). Excludes deleted stacks (`DELETE_COMPLETE`, `DELETE_IN_PROGRESS`) via `StackStatusFilter`. Each item is an AWS SDK `StackSummary` (e.g. `StackName`, `StackStatus`, `CreationTime`).

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ If the names don't match, the deletion will be aborted.
 
 ### Nested stacks and IAM
 
-Change sets request **`CAPABILITY_IAM`**, **`CAPABILITY_NAMED_IAM`**, and **`CAPABILITY_AUTO_EXPAND`**, so stacks with unnamed or named IAM resources and **nested stacks** (including templates from [`aws cloudformation package`](https://docs.aws.amazon.com/cli/latest/reference/cloudformation/package.html)) work with **`create-stack`** / **`update-stack`** and the SDK `createStack` / `updateStack` helpers.
+Change sets request **`CAPABILITY_NAMED_IAM`** and **`CAPABILITY_AUTO_EXPAND`**, so stacks that define named IAM resources or **nested stacks** (including templates from [`aws cloudformation package`](https://docs.aws.amazon.com/cli/latest/reference/cloudformation/package.html)) work with **`create-stack`** / **`update-stack`** and the SDK `createStack` / `updateStack` helpers.
 
 ### 📋 `listStacks(): Promise<StackSummary[]>`
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ If the names don't match, the deletion will be aborted.
 
 ### Nested stacks and IAM
 
-Change sets request **`CAPABILITY_NAMED_IAM`** and **`CAPABILITY_AUTO_EXPAND`**, so stacks that define named IAM resources or **nested stacks** (including templates from [`aws cloudformation package`](https://docs.aws.amazon.com/cli/latest/reference/cloudformation/package.html)) work with **`create-stack`** / **`update-stack`** and the SDK `createStack` / `updateStack` helpers.
+Change sets request **`CAPABILITY_IAM`**, **`CAPABILITY_NAMED_IAM`**, and **`CAPABILITY_AUTO_EXPAND`**, so stacks with unnamed or named IAM resources and **nested stacks** (including templates from [`aws cloudformation package`](https://docs.aws.amazon.com/cli/latest/reference/cloudformation/package.html)) work with **`create-stack`** / **`update-stack`** and the SDK `createStack` / `updateStack` helpers.
 
 ### 📋 `listStacks(): Promise<StackSummary[]>`
 

--- a/src/lib/cfn/executeChangeSet.ts
+++ b/src/lib/cfn/executeChangeSet.ts
@@ -46,11 +46,7 @@ async function createChangeSet<P extends TemplateParams>(
         ChangeSetName: changeSetName,
         ChangeSetType: operation,
         Parameters: parameters,
-        Capabilities: [
-            'CAPABILITY_IAM',
-            'CAPABILITY_NAMED_IAM',
-            'CAPABILITY_AUTO_EXPAND',
-        ],
+        Capabilities: ['CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
     }));
 
     const cfg = getOutputConfig();

--- a/src/lib/cfn/executeChangeSet.ts
+++ b/src/lib/cfn/executeChangeSet.ts
@@ -46,7 +46,11 @@ async function createChangeSet<P extends TemplateParams>(
         ChangeSetName: changeSetName,
         ChangeSetType: operation,
         Parameters: parameters,
-        Capabilities: ['CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
+        Capabilities: [
+            'CAPABILITY_IAM',
+            'CAPABILITY_NAMED_IAM',
+            'CAPABILITY_AUTO_EXPAND',
+        ],
     }));
 
     const cfg = getOutputConfig();

--- a/src/lib/cfn/executeChangeSet.ts
+++ b/src/lib/cfn/executeChangeSet.ts
@@ -46,7 +46,7 @@ async function createChangeSet<P extends TemplateParams>(
         ChangeSetName: changeSetName,
         ChangeSetType: operation,
         Parameters: parameters,
-        Capabilities: ['CAPABILITY_NAMED_IAM'],
+        Capabilities: ['CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
     }));
 
     const cfg = getOutputConfig();


### PR DESCRIPTION
Nested stacks and packaged templates need **CAPABILITY_AUTO_EXPAND** in addition to **CAPABILITY_NAMED_IAM** when creating change sets (same as `aws cloudformation deploy --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND`).

- Set both capabilities in `createChangeSet` (`executeChangeSet.ts`).
- Document in README under API Reference.

Validated with `npm run validate`.