### PR TITLE
feat: update-stack --create

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ awscfn update-stack -n <STACK_NAME> -t <TEMPLATE_FILE> -p <PARAMS_FILE>
 | `--name`, `-n` | Stack name |
 | `--template`, `-t` | CloudFormation template file |
 | `--params`, `-p` | Parameters file (YAML) |
-| `--createIfMissing`, `-m` | If the stack doesn't exist, create it instead of erroring |
+| `--create` | If the stack doesn't exist, create it (instead of erroring) |
+| `--createIfMissing`, `-m` | Alias for `--create` |
 
 If there are no changes to apply, the command succeeds gracefully:
 ```

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ awscfn update-stack -n <STACK_NAME> -t <TEMPLATE_FILE> -p <PARAMS_FILE>
 | `--name`, `-n` | Stack name |
 | `--template`, `-t` | CloudFormation template file |
 | `--params`, `-p` | Parameters file (YAML) |
+| `--createIfMissing`, `-m` | If the stack doesn't exist, create it instead of erroring |
 
 If there are no changes to apply, the command succeeds gracefully:
 ```

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ awscfn update-stack -n <STACK_NAME> -t <TEMPLATE_FILE> -p <PARAMS_FILE>
 | `--template`, `-t` | CloudFormation template file |
 | `--params`, `-p` | Parameters file (YAML) |
 | `--create` | If the stack doesn't exist, create it (instead of erroring) |
-| `--createIfMissing`, `-m` | Alias for `--create` |
+| `-m` | Shorthand for `--create` |
 
 If there are no changes to apply, the command succeeds gracefully:
 ```

--- a/bin/awscfn
+++ b/bin/awscfn
@@ -91,6 +91,15 @@ const templateOpt = {
 const paramsOpt = {
   params: { type: 'string', alias: 'p', describe: 'Parameters file (YAML). Optional; omit to use template defaults.', demandOption: false },
 };
+const createIfMissingOpt = {
+  createIfMissing: {
+    type: 'boolean',
+    alias: 'm',
+    describe: 'If the stack does not exist, create it instead of erroring (update-stack only)',
+    demandOption: false,
+    default: false,
+  },
+};
 const confirmOpt = {
   confirm: { type: 'string', alias: 'c', describe: 'Repeat stack name to confirm deletion', demandOption: true },
 };
@@ -156,9 +165,9 @@ yargs
   .command(
     'update-stack',
     'Update a CloudFormation stack',
-    (cmd) => cmd.options({ ...nameOpt, ...templateOpt, ...paramsOpt }),
-    ({ name, template, params }) => {
-      runCommand(() => updateStack(name, template, params));
+    (cmd) => cmd.options({ ...nameOpt, ...templateOpt, ...paramsOpt, ...createIfMissingOpt }),
+    ({ name, template, params, createIfMissing }) => {
+      runCommand(() => updateStack(name, template, params, createIfMissing));
     }
   )
   .command(

--- a/bin/awscfn
+++ b/bin/awscfn
@@ -92,18 +92,10 @@ const paramsOpt = {
   params: { type: 'string', alias: 'p', describe: 'Parameters file (YAML). Optional; omit to use template defaults.', demandOption: false },
 };
 const createIfMissingOpt = {
-  // Preferred flag name.
   create: {
     type: 'boolean',
     alias: 'm',
     describe: 'Create the stack if it does not exist (update-stack only)',
-    demandOption: false,
-    default: false,
-  },
-  // Backwards-compatible alias. Hidden so help output doesn't teach the old name.
-  createIfMissing: {
-    type: 'boolean',
-    hidden: true,
     demandOption: false,
     default: false,
   },
@@ -174,8 +166,8 @@ yargs
     'update-stack',
     'Update a CloudFormation stack',
     (cmd) => cmd.options({ ...nameOpt, ...templateOpt, ...paramsOpt, ...createIfMissingOpt }),
-    ({ name, template, params, create, createIfMissing }) => {
-      runCommand(() => updateStack(name, template, params, Boolean(create || createIfMissing)));
+    ({ name, template, params, create }) => {
+      runCommand(() => updateStack(name, template, params, Boolean(create)));
     }
   )
   .command(

--- a/bin/awscfn
+++ b/bin/awscfn
@@ -92,10 +92,18 @@ const paramsOpt = {
   params: { type: 'string', alias: 'p', describe: 'Parameters file (YAML). Optional; omit to use template defaults.', demandOption: false },
 };
 const createIfMissingOpt = {
+  // Preferred flag name.
+  create: {
+    type: 'boolean',
+    describe: 'Create the stack if it does not exist (update-stack only)',
+    demandOption: false,
+    default: false,
+  },
+  // Backwards-compatible alias.
   createIfMissing: {
     type: 'boolean',
     alias: 'm',
-    describe: 'If the stack does not exist, create it instead of erroring (update-stack only)',
+    describe: 'Alias for --create (create the stack if it does not exist)',
     demandOption: false,
     default: false,
   },
@@ -166,8 +174,8 @@ yargs
     'update-stack',
     'Update a CloudFormation stack',
     (cmd) => cmd.options({ ...nameOpt, ...templateOpt, ...paramsOpt, ...createIfMissingOpt }),
-    ({ name, template, params, createIfMissing }) => {
-      runCommand(() => updateStack(name, template, params, createIfMissing));
+    ({ name, template, params, create, createIfMissing }) => {
+      runCommand(() => updateStack(name, template, params, Boolean(create || createIfMissing)));
     }
   )
   .command(

--- a/bin/awscfn
+++ b/bin/awscfn
@@ -95,15 +95,15 @@ const createIfMissingOpt = {
   // Preferred flag name.
   create: {
     type: 'boolean',
+    alias: 'm',
     describe: 'Create the stack if it does not exist (update-stack only)',
     demandOption: false,
     default: false,
   },
-  // Backwards-compatible alias.
+  // Backwards-compatible alias. Hidden so help output doesn't teach the old name.
   createIfMissing: {
     type: 'boolean',
-    alias: 'm',
-    describe: 'Alias for --create (create the stack if it does not exist)',
+    hidden: true,
     demandOption: false,
     default: false,
   },

--- a/src/updateStack.ts
+++ b/src/updateStack.ts
@@ -10,7 +10,7 @@ export async function updateStack(
     stackName: string,
     templatePath: string,
     paramsPath?: string,
-    createIfMissing: boolean = false,
+    create: boolean = false,
 ): Promise<void> {
 
     cfn.initCloudFormationClient();
@@ -20,7 +20,7 @@ export async function updateStack(
 
     if (!existing) {
 
-        if (!createIfMissing) {
+        if (!create) {
 
             throw new Error('stack not found, try create command');
 

--- a/src/updateStack.ts
+++ b/src/updateStack.ts
@@ -10,6 +10,7 @@ export async function updateStack(
     stackName: string,
     templatePath: string,
     paramsPath?: string,
+    createIfMissing: boolean = false,
 ): Promise<void> {
 
     cfn.initCloudFormationClient();
@@ -19,7 +20,19 @@ export async function updateStack(
 
     if (!existing) {
 
-        throw new Error('stack not found, try create command');
+        if (!createIfMissing) {
+
+            throw new Error('stack not found, try create command');
+
+        }
+
+        console.log('validating template...');
+        await validateTemplateOrExit(template);
+
+        logStackAction(stackName, 'creating', params);
+        await cfn.createStack(stackName, {body: template, params});
+
+        return;
 
     }
 


### PR DESCRIPTION
Adds `--create` (`-m`) to `awscfn update-stack`.

- Default behavior unchanged: update requires the stack to exist.
- With `--create`: if the stack is missing, awscfn validates the template then creates the stack using the same deploy flow.

No other aliases are supported.