### PR TITLE
feat: add --set param overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ awscfn create-stack -n <STACK_NAME> -t <TEMPLATE_FILE> -p <PARAMS_FILE>
 | `--name`, `-n` | Stack name |
 | `--template`, `-t` | CloudFormation template file |
 | `--params`, `-p` | Parameters file (YAML) |
+| `--set` | Override one or more parameters (repeatable `Key=Value`) |
 
 ### ⬆️ update-stack
 
@@ -127,6 +128,7 @@ awscfn update-stack -n <STACK_NAME> -t <TEMPLATE_FILE> -p <PARAMS_FILE>
 | `--name`, `-n` | Stack name |
 | `--template`, `-t` | CloudFormation template file |
 | `--params`, `-p` | Parameters file (YAML) |
+| `--set` | Override one or more parameters (repeatable `Key=Value`). You can omit `--params` to override only specific values on an existing stack. |
 | `--create` | If the stack doesn't exist, create it (instead of erroring) |
 | `-m` | Shorthand for `--create` |
 
@@ -148,6 +150,7 @@ awscfn preview-stack -n <STACK_NAME> -t <TEMPLATE_FILE> -p <PARAMS_FILE>
 | `--name`, `-n` | Stack name |
 | `--template`, `-t` | CloudFormation template file |
 | `--params`, `-p` | Parameters file (YAML) |
+| `--set` | Override one or more parameters (repeatable `Key=Value`) |
 
 Use this to review Add / Modify / Remove actions (and replacement hints) before running **`create-stack`** or **`update-stack`**.
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ awscfn create-stack -n <STACK_NAME> -t <TEMPLATE_FILE> -p <PARAMS_FILE>
 | `--name`, `-n` | Stack name |
 | `--template`, `-t` | CloudFormation template file |
 | `--params`, `-p` | Parameters file (YAML) |
-| `--set` | Override one or more parameters (repeatable `Key=Value`) |
+| `--set`, `-s` | Override one or more parameters (repeatable `Key=Value`) |
 
 ### ⬆️ update-stack
 
@@ -128,7 +128,7 @@ awscfn update-stack -n <STACK_NAME> -t <TEMPLATE_FILE> -p <PARAMS_FILE>
 | `--name`, `-n` | Stack name |
 | `--template`, `-t` | CloudFormation template file |
 | `--params`, `-p` | Parameters file (YAML) |
-| `--set` | Override one or more parameters (repeatable `Key=Value`). You can omit `--params` to override only specific values on an existing stack. |
+| `--set`, `-s` | Override one or more parameters (repeatable `Key=Value`). You can omit `--params` to override only specific values on an existing stack. |
 | `--create` | If the stack doesn't exist, create it (instead of erroring) |
 | `-m` | Shorthand for `--create` |
 
@@ -150,7 +150,7 @@ awscfn preview-stack -n <STACK_NAME> -t <TEMPLATE_FILE> -p <PARAMS_FILE>
 | `--name`, `-n` | Stack name |
 | `--template`, `-t` | CloudFormation template file |
 | `--params`, `-p` | Parameters file (YAML) |
-| `--set` | Override one or more parameters (repeatable `Key=Value`) |
+| `--set`, `-s` | Override one or more parameters (repeatable `Key=Value`) |
 
 Use this to review Add / Modify / Remove actions (and replacement hints) before running **`create-stack`** or **`update-stack`**.
 

--- a/bin/awscfn
+++ b/bin/awscfn
@@ -91,6 +91,15 @@ const templateOpt = {
 const paramsOpt = {
   params: { type: 'string', alias: 'p', describe: 'Parameters file (YAML). Optional; omit to use template defaults.', demandOption: false },
 };
+const setOpt = {
+  set: {
+    type: 'string',
+    array: true,
+    describe: 'Override one or more parameters (repeatable). Format: Key=Value',
+    demandOption: false,
+    default: [],
+  },
+};
 const createIfMissingOpt = {
   create: {
     type: 'boolean',
@@ -141,9 +150,9 @@ yargs
   .command(
     'create-stack',
     'Create a CloudFormation stack',
-    (cmd) => cmd.options({ ...nameOpt, ...templateOpt, ...paramsOpt }),
-    ({ name, template, params }) => {
-      runCommand(() => createStack(name, template, params));
+    (cmd) => cmd.options({ ...nameOpt, ...templateOpt, ...paramsOpt, ...setOpt }),
+    ({ name, template, params, set }) => {
+      runCommand(() => createStack(name, template, params, require('../dist/cli/parseParamOverrides').parseParamOverrides(set).overrides));
     }
   )
   .command(
@@ -165,17 +174,17 @@ yargs
   .command(
     'update-stack',
     'Update a CloudFormation stack',
-    (cmd) => cmd.options({ ...nameOpt, ...templateOpt, ...paramsOpt, ...createIfMissingOpt }),
-    ({ name, template, params, create }) => {
-      runCommand(() => updateStack(name, template, params, Boolean(create)));
+    (cmd) => cmd.options({ ...nameOpt, ...templateOpt, ...paramsOpt, ...createIfMissingOpt, ...setOpt }),
+    ({ name, template, params, create, set }) => {
+      runCommand(() => updateStack(name, template, params, Boolean(create), require('../dist/cli/parseParamOverrides').parseParamOverrides(set).overrides));
     }
   )
   .command(
     'preview-stack',
     'Preview changes without deploying (change set only)',
-    (cmd) => cmd.options({ ...nameOpt, ...templateOpt, ...paramsOpt }),
-    ({ name, template, params }) => {
-      runCommand(() => previewStack(name, template, params));
+    (cmd) => cmd.options({ ...nameOpt, ...templateOpt, ...paramsOpt, ...setOpt }),
+    ({ name, template, params, set }) => {
+      runCommand(() => previewStack(name, template, params, require('../dist/cli/parseParamOverrides').parseParamOverrides(set).overrides));
     }
   )
   .completion(

--- a/bin/awscfn
+++ b/bin/awscfn
@@ -94,6 +94,7 @@ const paramsOpt = {
 const setOpt = {
   set: {
     type: 'string',
+    alias: 's',
     array: true,
     describe: 'Override one or more parameters (repeatable). Format: Key=Value',
     demandOption: false,

--- a/src/cli/loadTemplateAndParams.spec.ts
+++ b/src/cli/loadTemplateAndParams.spec.ts
@@ -1,0 +1,20 @@
+import {test} from 'kizu';
+import {mkdtempSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {loadTemplateAndParams} from './loadTemplateAndParams';
+
+test('loadTemplateAndParams throws when template has no Parameters but overrides provided', async (assert) => {
+
+    const dir = mkdtempSync(join(tmpdir(), 'awscfn-'));
+    const templatePath = join(dir, 'template.yaml');
+
+    writeFileSync(templatePath, 'Resources: {}', 'utf-8');
+
+    await assert.throws(
+        () => loadTemplateAndParams(templatePath, undefined, {Foo: 'bar'}),
+        /does not declare Parameters/i,
+    );
+
+});
+

--- a/src/cli/loadTemplateAndParams.ts
+++ b/src/cli/loadTemplateAndParams.ts
@@ -18,9 +18,19 @@ export async function loadTemplateAndParams(
 ): Promise<TemplateAndParams> {
 
     const template = readFileSync(templatePath, 'utf-8');
+    const hasParameters = templateHasParameters(template);
     const fileParams = (paramsPath && templateHasParameters(template))
         ? ((await getParamsFromFile(paramsPath)) as Record<string, unknown>)
         : {};
+
+    if (!hasParameters && overrides && Object.keys(overrides).length > 0) {
+
+        throw new Error(
+            'Template does not declare Parameters, but --set was provided. '
+            + 'Remove --set or add a Parameters section to the template.',
+        );
+
+    }
 
     const params = {
         ...fileParams,

--- a/src/cli/loadTemplateAndParams.ts
+++ b/src/cli/loadTemplateAndParams.ts
@@ -14,12 +14,18 @@ export interface TemplateAndParams {
 export async function loadTemplateAndParams(
     templatePath: string,
     paramsPath: string | undefined,
+    overrides?: Record<string, string>,
 ): Promise<TemplateAndParams> {
 
     const template = readFileSync(templatePath, 'utf-8');
-    const params = (paramsPath && templateHasParameters(template))
+    const fileParams = (paramsPath && templateHasParameters(template))
         ? ((await getParamsFromFile(paramsPath)) as Record<string, unknown>)
         : {};
+
+    const params = {
+        ...fileParams,
+        ...(overrides ?? {}),
+    };
 
     return {template, params};
 

--- a/src/cli/parseParamOverrides.spec.ts
+++ b/src/cli/parseParamOverrides.spec.ts
@@ -1,0 +1,25 @@
+import {test} from 'kizu';
+import {parseParamOverrides} from './parseParamOverrides';
+
+test('parseParamOverrides parses repeated Key=Value pairs', (assert) => {
+
+    const {overrides} = parseParamOverrides(['Foo=bar', 'Env=prod']);
+
+    assert.equal(overrides, {Foo: 'bar', Env: 'prod'});
+
+});
+
+test('parseParamOverrides last value wins for duplicate keys', (assert) => {
+
+    const {overrides} = parseParamOverrides(['Foo=bar', 'Foo=baz']);
+
+    assert.equal(overrides, {Foo: 'baz'});
+
+});
+
+test('parseParamOverrides throws on invalid format', (assert) => {
+
+    assert.throws(() => parseParamOverrides(['NoEquals'] as any), /expected Key=Value/);
+
+});
+

--- a/src/cli/parseParamOverrides.ts
+++ b/src/cli/parseParamOverrides.ts
@@ -1,0 +1,35 @@
+export interface ParamOverrideParseResult {
+    overrides: Record<string, string>;
+}
+
+/**
+ * Parse repeatable CLI overrides like:
+ *   ["Foo=bar", "Env=prod"]
+ */
+export function parseParamOverrides(values: unknown[] | undefined): ParamOverrideParseResult {
+
+    const overrides: Record<string, string> = {};
+
+    if (!values) return {overrides};
+
+    for (const raw of values) {
+
+        if (typeof raw !== 'string') throw new Error(`Invalid --set value: ${String(raw)}`);
+
+        const idx = raw.indexOf('=');
+
+        if (idx <= 0) throw new Error(`Invalid --set value (expected Key=Value): ${raw}`);
+
+        const key = raw.slice(0, idx).trim();
+        const value = raw.slice(idx + 1);
+
+        if (!key) throw new Error(`Invalid --set value (empty key): ${raw}`);
+
+        overrides[key] = value;
+
+    }
+
+    return {overrides};
+
+}
+

--- a/src/createStack.ts
+++ b/src/createStack.ts
@@ -10,11 +10,12 @@ export async function createStack(
     stackName: string,
     templatePath: string,
     paramsPath?: string,
+    overrides?: Record<string, string>,
 ): Promise<void> {
 
     cfn.initCloudFormationClient();
 
-    const {template, params} = await loadTemplateAndParams(templatePath, paramsPath);
+    const {template, params} = await loadTemplateAndParams(templatePath, paramsPath, overrides);
     const existing = await cfn.getStackByName(stackName);
 
     if (existing) {

--- a/src/previewStack.ts
+++ b/src/previewStack.ts
@@ -12,11 +12,12 @@ export async function previewStack(
     stackName: string,
     templatePath: string,
     paramsPath?: string,
+    overrides?: Record<string, string>,
 ): Promise<void> {
 
     cfn.initCloudFormationClient();
 
-    const {template, params} = await loadTemplateAndParams(templatePath, paramsPath);
+    const {template, params} = await loadTemplateAndParams(templatePath, paramsPath, overrides);
     const existing = await cfn.getStackByName(stackName);
 
     if (existing?.StackStatus === StackStatus.ROLLBACK_COMPLETE) {

--- a/src/updateStack.ts
+++ b/src/updateStack.ts
@@ -11,11 +11,12 @@ export async function updateStack(
     templatePath: string,
     paramsPath?: string,
     create: boolean = false,
+    overrides?: Record<string, string>,
 ): Promise<void> {
 
     cfn.initCloudFormationClient();
 
-    const {template, params} = await loadTemplateAndParams(templatePath, paramsPath);
+    const {template, params} = await loadTemplateAndParams(templatePath, paramsPath, overrides);
     const existing = await cfn.getStackByName(stackName);
 
     if (!existing) {


### PR DESCRIPTION
## Summary
- Add repeatable `--set Key=Value` to override CloudFormation parameters in `create-stack`, `update-stack`, and `preview-stack`.
- Merge precedence: params file values are loaded first, then `--set` overrides.

## Test plan
- `npm run validate`