### PR TITLE
feat: add interactive inspect-stack multi-pane TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ awscfn list-stacks
 
 ### 🔎 inspect-stack
 
-Inspect a **deployed** stack in a **read-only pager view** (TUI-like), including:
+Inspect a **deployed** stack in an **interactive multi-pane TUI** (with pager/text fallback), including:
 
 - full deployed template body
 - current parameters and outputs
@@ -122,7 +122,7 @@ awscfn inspect-stack -n <STACK_NAME>
 |------|-------------|
 | `--name`, `-n` | Stack name |
 | `--events`, `-e` | Max stack events to fetch (`0` = all available events). Default `500` |
-| `--pager` / `--no-pager` | Use a view-only pager (default true). Disable to print directly |
+| `--pager` / `--no-pager` | Use interactive TUI/pager output (default true). Disable to print directly |
 
 This command performs read-only CloudFormation API calls (`DescribeStacks`, `GetTemplate`, `DescribeStackEvents`) and makes no stack changes.
 

--- a/bin/awscfn
+++ b/bin/awscfn
@@ -345,7 +345,7 @@ const eventsLimitOpt = {
 const pagerOpt = {
   pager: {
     type: 'boolean',
-    describe: 'Open output in a view-only pager (use --no-pager to print directly)',
+    describe: 'Use interactive TUI/pager output (use --no-pager to print directly)',
     demandOption: false,
     default: true,
   },
@@ -355,7 +355,7 @@ const cli = yargs
   .scriptName('awscfn')
   .usage('Usage:\n  $0 <command> [options]')
   .example('$0 list-stacks', 'List active stacks in the current AWS region')
-  .example('$0 inspect-stack -n my-stack', 'Open a read-only stack inspection view')
+  .example('$0 inspect-stack -n my-stack', 'Open interactive stack inspection panes')
   .example('$0 update-stack -n my-stack -t ./template.yaml -p ./params.yaml', 'Update an existing stack')
   .epilog('Tip: run `awscfn <command> --help` for command-specific help.')
   .option('ci', {
@@ -433,7 +433,7 @@ const cli = yargs
   )
   .command(
     'inspect-stack',
-    'Inspect a deployed stack in a read-only pager view',
+    'Inspect a deployed stack in interactive panes (with fallback)',
     (cmd) => cmd.options({ ...nameOpt, ...eventsLimitOpt, ...pagerOpt }),
     ({ name, events, pager }) => {
       runCommand(() => inspectStack(name, { eventsLimit: Number(events), usePager: Boolean(pager) }));

--- a/src/inspectStack.ts
+++ b/src/inspectStack.ts
@@ -1,6 +1,7 @@
 import {Stack, StackEvent} from '@aws-sdk/client-cloudformation';
 import * as cfn from './lib/cfn';
 import {viewText} from './lib/viewText';
+import {InspectTuiSection, viewInspectTui} from './lib/viewInspectTui';
 
 export interface InspectStackOptions {
     eventsLimit: number
@@ -117,7 +118,7 @@ function formatParameters(stack: Stack): string {
     if (params.length === 0) return 'No parameters on stack.';
 
     return params
-        .map((param) => `${param.ParameterKey ?? 'Unknown'}=${param.ParameterValue ?? '(no value returned)'}`)
+        .map((param) => `${param.ParameterKey ?? 'Unknown'}: ${param.ParameterValue ?? '(no value returned)'}`)
         .join('\n');
 
 }
@@ -128,7 +129,7 @@ function formatOutputs(stack: Stack): string {
 
     if (outputs.length === 0) return 'No outputs on stack.';
 
-    return outputs.map((output) => `${output.OutputKey ?? 'Unknown'}=${output.OutputValue ?? ''}`).join('\n');
+    return outputs.map((output) => `${output.OutputKey ?? 'Unknown'}: ${output.OutputValue ?? ''}`).join('\n');
 
 }
 
@@ -203,21 +204,37 @@ function stackSummary(stack: Stack): string {
 
 }
 
-function buildReport(stack: Stack, templateBody: string, events: StackEvent[], options: InspectStackOptions): string {
+function buildSections(
+    stack: Stack,
+    templateBody: string,
+    events: StackEvent[],
+    options: InspectStackOptions,
+): InspectTuiSection[] {
 
     const failures = getFailureEvents(toChronological(events));
-    const sections = [
-        formatSection('Stack Summary', stackSummary(stack)),
-        formatSection('Stack Details (Raw JSON)', stackDetailsJson(stack)),
-        formatSection('Parameters', formatParameters(stack)),
-        formatSection('Outputs', formatOutputs(stack)),
-        formatSection('Likely Root Causes', formatRootCauses(failures)),
-        formatSection('Failure Events', formatFailureEvents(failures)),
-        formatSection('Events', formatEvents(events, options.eventsLimit)),
-        formatSection('Full Deployed Template', templateBody || 'Template body is empty.'),
+    const sections: InspectTuiSection[] = [
+        {title: 'Stack Summary', body: stackSummary(stack)},
+        {title: 'Stack Details (Raw JSON)', body: stackDetailsJson(stack)},
+        {title: 'Parameters', body: formatParameters(stack)},
+        {title: 'Outputs', body: formatOutputs(stack)},
+        {title: 'Likely Root Causes', body: formatRootCauses(failures)},
+        {title: 'Failure Events', body: formatFailureEvents(failures)},
+        {title: 'Events', body: formatEvents(events, options.eventsLimit)},
+        {title: 'Full Deployed Template', body: templateBody || 'Template body is empty.'},
     ];
 
-    return ['awscfn inspect-stack', '='.repeat(20), '', ...sections].join('\n\n');
+    return sections;
+
+}
+
+function buildReport(sections: InspectTuiSection[]): string {
+
+    return [
+        'awscfn inspect-stack',
+        '='.repeat(20),
+        '',
+        ...sections.map((section) => formatSection(section.title, section.body)),
+    ].join('\n\n');
 
 }
 
@@ -238,7 +255,29 @@ export async function inspectStack(
         cfn.listStackEvents(stackName, resolvedOptions.eventsLimit),
     ]);
 
-    const report = buildReport(stack, templateBody, events, resolvedOptions);
+    const sections = buildSections(stack, templateBody, events, resolvedOptions);
+
+    if (resolvedOptions.usePager) {
+
+        const didShowTui = await viewInspectTui(sections, {
+            title: `awscfn inspect-stack: ${stackName}`,
+            subtitle: [
+                'Tab switches focus.',
+                'Up/Down navigates.',
+                'PgUp/PgDn scrolls.',
+                'q quits.',
+            ].join(' '),
+        });
+
+        if (didShowTui) {
+
+            return;
+
+        }
+
+    }
+
+    const report = buildReport(sections);
 
     viewText(`inspect-${stackName}`, report, {usePager: resolvedOptions.usePager});
 

--- a/src/lib/viewInspectTui.ts
+++ b/src/lib/viewInspectTui.ts
@@ -1,0 +1,545 @@
+import {stdin, stdout} from 'node:process';
+
+export interface InspectTuiSection {
+    title: string
+    body: string
+}
+
+export interface InspectTuiOptions {
+    title: string
+    subtitle: string
+}
+
+type FocusMode = 'sections'|'content';
+type KeyAction = 'noop'|'rerender'|'quit';
+
+interface InspectTuiState {
+    sections: InspectTuiSection[]
+    activeSectionIndex: number
+    scrollOffset: number
+    focusMode: FocusMode
+    options: InspectTuiOptions
+    useColor: boolean
+}
+
+interface TuiLayout {
+    width: number
+    height: number
+    sidebarWidth: number
+    contentWidth: number
+    bodyHeight: number
+}
+
+const MIN_WIDTH = 70;
+const MIN_HEIGHT = 16;
+const KEY_PAGE_UP = '\u001b[5~';
+const KEY_PAGE_DOWN = '\u001b[6~';
+const KEY_ARROW_UP = '\u001b[A';
+const KEY_ARROW_DOWN = '\u001b[B';
+const KEY_ARROW_LEFT = '\u001b[D';
+const KEY_ARROW_RIGHT = '\u001b[C';
+
+function supportsInteractiveTui(): boolean {
+
+    return stdin.isTTY === true
+        && stdout.isTTY === true
+        && process.env.CI !== 'true'
+        && process.env.GITHUB_ACTIONS !== 'true';
+
+}
+
+function colorize(text: string, ansiCode: string, enabled: boolean): string {
+
+    if (!enabled) return text;
+
+    return `${ansiCode}${text}\x1b[0m`;
+
+}
+
+function highlightStatusToken(token: string, useColor: boolean): string {
+
+    if (/FAILED|ROLLBACK/.test(token)) {
+
+        return colorize(token, '\x1b[31m', useColor);
+
+    }
+    if (/COMPLETE|SUCCEEDED/.test(token)) {
+
+        return colorize(token, '\x1b[32m', useColor);
+
+    }
+    if (/IN_PROGRESS|PENDING/.test(token)) {
+
+        return colorize(token, '\x1b[33m', useColor);
+
+    }
+
+    return token;
+
+}
+
+function highlightStatusTerms(line: string, useColor: boolean): string {
+
+    return line.replace(/\b[A-Z]+(?:_[A-Z]+)+\b/g, (token) => highlightStatusToken(token, useColor));
+
+}
+
+function highlightTimestamp(line: string, useColor: boolean): string {
+
+    return line.replace(
+        /\[(\d{4}-\d{2}-\d{2}T[^\]]+)\]/g,
+        (_match, timestamp) => colorize(`[${timestamp}]`, '\x1b[90m', useColor),
+    );
+
+}
+
+function highlightKeyValueLine(line: string, useColor: boolean): string {
+
+    const jsonMatch = line.match(/^(\s*)"([^"]+)"(\s*:.*)$/);
+
+    if (jsonMatch) {
+
+        const [, indent, key, suffix] = jsonMatch;
+
+        return `${indent}${colorize(`"${key}"`, '\x1b[36m', useColor)}${suffix}`;
+
+    }
+
+    const kvMatch = line.match(/^(\s*)([A-Za-z][A-Za-z0-9_\-. ()/]*)(:\s*.*)$/);
+
+    if (!kvMatch) return line;
+
+    const [, indent, key, suffix] = kvMatch;
+
+    return `${indent}${colorize(key, '\x1b[36m', useColor)}${suffix}`;
+
+}
+
+function highlightLabels(line: string, useColor: boolean): string {
+
+    return line.replace(/\bReason:/g, () => colorize('Reason:', '\x1b[33m', useColor));
+
+}
+
+function styleContentLine(line: string, sectionTitle: string, useColor: boolean): string {
+
+    let styled = line;
+
+    if (sectionTitle.includes('Raw JSON') || sectionTitle.includes('Template') || line.includes(':')) {
+
+        styled = highlightKeyValueLine(styled, useColor);
+
+    }
+
+    styled = highlightTimestamp(styled, useColor);
+    styled = highlightStatusTerms(styled, useColor);
+    styled = highlightLabels(styled, useColor);
+
+    return styled;
+
+}
+
+function truncateText(text: string, width: number): string {
+
+    if (width <= 0) return '';
+    if (text.length <= width) return text;
+    if (width <= 3) return text.slice(0, width);
+
+    return `${text.slice(0, width - 3)}...`;
+
+}
+
+function padText(text: string, width: number): string {
+
+    if (text.length >= width) return text;
+
+    return `${text}${' '.repeat(width - text.length)}`;
+
+}
+
+function fitLine(text: string, width: number): string {
+
+    return padText(truncateText(text, width), width);
+
+}
+
+function wrapLine(line: string, width: number): string[] {
+
+    if (line.length === 0) return [''];
+
+    const out: string[] = [];
+    let offset = 0;
+
+    while (offset < line.length) {
+
+        out.push(line.slice(offset, offset + width));
+        offset += width;
+
+    }
+
+    return out;
+
+}
+
+function wrapBody(body: string, width: number): string[] {
+
+    const lines = body.replace(/\r\n/g, '\n').split('\n');
+    const wrapped: string[] = [];
+
+    for (const line of lines) {
+
+        wrapped.push(...wrapLine(line, width));
+
+    }
+
+    return wrapped;
+
+}
+
+function getLayout(): TuiLayout {
+
+    const width = Math.max(40, stdout.columns ?? 80);
+    const height = Math.max(10, stdout.rows ?? 24);
+    const sidebarWidth = Math.max(18, Math.min(30, Math.floor(width * 0.28)));
+    const contentWidth = Math.max(20, width - sidebarWidth - 3);
+    const bodyHeight = Math.max(3, height - 5);
+
+    return {width, height, sidebarWidth, contentWidth, bodyHeight};
+
+}
+
+function isLayoutTooSmall(layout: TuiLayout): boolean {
+
+    return layout.width < MIN_WIDTH || layout.height < MIN_HEIGHT;
+
+}
+
+function currentContentLines(state: InspectTuiState, layout: TuiLayout): string[] {
+
+    const section = state.sections[state.activeSectionIndex];
+
+    return wrapBody(section.body, layout.contentWidth);
+
+}
+
+function maxScrollOffset(contentLines: string[], layout: TuiLayout): number {
+
+    return Math.max(0, contentLines.length - layout.bodyHeight);
+
+}
+
+function sectionWindowStart(state: InspectTuiState, layout: TuiLayout): number {
+
+    const maxStart = Math.max(0, state.sections.length - layout.bodyHeight);
+    const preferred = Math.max(0, state.activeSectionIndex - Math.floor(layout.bodyHeight / 2));
+
+    return Math.min(preferred, maxStart);
+
+}
+
+function renderSidebarLine(
+    title: string,
+    isActive: boolean,
+    hasFocus: boolean,
+    width: number,
+    useColor: boolean,
+): string {
+
+    const marker = isActive ? '>' : ' ';
+    const content = fitLine(`${marker} ${title}`, width);
+
+    if (!isActive) return content;
+    if (hasFocus) return colorize(content, '\x1b[1;36m', useColor);
+
+    return colorize(content, '\x1b[36m', useColor);
+
+}
+
+function renderHeader(state: InspectTuiState, layout: TuiLayout): string[] {
+
+    const title = colorize(fitLine(state.options.title, layout.width), '\x1b[1;37m', state.useColor);
+    const subtitle = colorize(fitLine(state.options.subtitle, layout.width), '\x1b[90m', state.useColor);
+    const divider = colorize('-'.repeat(layout.width), '\x1b[90m', state.useColor);
+
+    return [title, subtitle, divider];
+
+}
+
+function renderBody(state: InspectTuiState, layout: TuiLayout, contentLines: string[]): string[] {
+
+    const start = sectionWindowStart(state, layout);
+    const visibleContent = contentLines.slice(state.scrollOffset, state.scrollOffset + layout.bodyHeight);
+    const rows: string[] = [];
+    const activeSection = state.sections[state.activeSectionIndex];
+    const divider = colorize('|', '\x1b[90m', state.useColor);
+
+    for (let row = 0; row < layout.bodyHeight; row++) {
+
+        const section = state.sections[start + row];
+        const left = section
+            ? renderSidebarLine(
+                section.title,
+                start + row === state.activeSectionIndex,
+                state.focusMode === 'sections',
+                layout.sidebarWidth,
+                state.useColor,
+            )
+            : fitLine('', layout.sidebarWidth);
+        const rightPlain = fitLine(visibleContent[row] ?? '', layout.contentWidth);
+        const right = styleContentLine(rightPlain, activeSection.title, state.useColor);
+
+        rows.push(`${left} ${divider} ${right}`);
+
+    }
+
+    return rows;
+
+}
+
+function renderFooter(state: InspectTuiState, layout: TuiLayout, contentLines: string[]): string[] {
+
+    const divider = colorize('-'.repeat(layout.width), '\x1b[90m', state.useColor);
+    const maxScroll = maxScrollOffset(contentLines, layout);
+    const startLine = contentLines.length === 0 ? 0 : state.scrollOffset + 1;
+    const endLine = Math.min(contentLines.length, state.scrollOffset + layout.bodyHeight);
+    const status = [
+        `Section ${state.activeSectionIndex + 1}/${state.sections.length}`,
+        `Lines ${startLine}-${endLine}/${Math.max(contentLines.length, 1)}`,
+        `Focus ${state.focusMode}`,
+        'Tab switch focus',
+        'Arrows navigate',
+        'PgUp/PgDn scroll',
+        'q quit',
+        maxScroll > 0 ? '' : 'No scroll',
+    ].filter(Boolean).join(' | ');
+
+    return [divider, colorize(fitLine(status, layout.width), '\x1b[90m', state.useColor)];
+
+}
+
+function smallTerminalFrame(layout: TuiLayout): string {
+
+    const lines = [
+        fitLine('awscfn inspect-stack', layout.width),
+        fitLine('', layout.width),
+        fitLine(`Terminal too small (${layout.width}x${layout.height}) for interactive mode.`, layout.width),
+        fitLine(`Resize to at least ${MIN_WIDTH}x${MIN_HEIGHT}, or use --no-pager.`, layout.width),
+        fitLine('', layout.width),
+        fitLine('Press q to quit.', layout.width),
+    ];
+
+    return lines.join('\n');
+
+}
+
+function buildFrame(state: InspectTuiState): string {
+
+    const layout = getLayout();
+
+    if (isLayoutTooSmall(layout)) {
+
+        return smallTerminalFrame(layout);
+
+    }
+
+    const contentLines = currentContentLines(state, layout);
+    const lines = [
+        ...renderHeader(state, layout),
+        ...renderBody(state, layout, contentLines),
+        ...renderFooter(state, layout, contentLines),
+    ];
+
+    return lines.join('\n');
+
+}
+
+function normalizeKey(input: string): string {
+
+    if (input === '\u0003') return 'QUIT';
+    if (input === '\u001b' || input === 'q') return 'QUIT';
+    if (input === '\t') return 'TAB';
+    if (input === KEY_ARROW_UP || input === 'k') return 'UP';
+    if (input === KEY_ARROW_DOWN || input === 'j') return 'DOWN';
+    if (input === KEY_ARROW_LEFT || input === 'h') return 'LEFT';
+    if (input === KEY_ARROW_RIGHT || input === 'l') return 'RIGHT';
+    if (input === KEY_PAGE_UP) return 'PGUP';
+    if (input === KEY_PAGE_DOWN) return 'PGDN';
+    if (input === 'g') return 'HOME';
+    if (input === 'G') return 'END';
+
+    return 'UNKNOWN';
+
+}
+
+function updateActiveSection(state: InspectTuiState, nextIndex: number): boolean {
+
+    const clamped = Math.max(0, Math.min(state.sections.length - 1, nextIndex));
+
+    if (clamped === state.activeSectionIndex) return false;
+
+    state.activeSectionIndex = clamped;
+    state.scrollOffset = 0;
+
+    return true;
+
+}
+
+function updateScroll(state: InspectTuiState, delta: number): boolean {
+
+    const layout = getLayout();
+    const contentLines = currentContentLines(state, layout);
+    const max = maxScrollOffset(contentLines, layout);
+    const next = Math.max(0, Math.min(max, state.scrollOffset + delta));
+
+    if (next === state.scrollOffset) return false;
+
+    state.scrollOffset = next;
+
+    return true;
+
+}
+
+function applyKey(state: InspectTuiState, key: string): KeyAction {
+
+    if (key === 'QUIT') return 'quit';
+    if (key === 'TAB') {
+
+        state.focusMode = state.focusMode === 'sections' ? 'content' : 'sections';
+
+        return 'rerender';
+
+    }
+    if (key === 'LEFT') return updateActiveSection(state, state.activeSectionIndex - 1) ? 'rerender' : 'noop';
+    if (key === 'RIGHT') return updateActiveSection(state, state.activeSectionIndex + 1) ? 'rerender' : 'noop';
+    if (key === 'HOME') return updateScroll(state, Number.MIN_SAFE_INTEGER) ? 'rerender' : 'noop';
+    if (key === 'END') return updateScroll(state, Number.MAX_SAFE_INTEGER) ? 'rerender' : 'noop';
+    if (key === 'PGUP') return updateScroll(state, -Math.max(1, getLayout().bodyHeight - 1)) ? 'rerender' : 'noop';
+    if (key === 'PGDN') return updateScroll(state, Math.max(1, getLayout().bodyHeight - 1)) ? 'rerender' : 'noop';
+    if (key === 'UP') {
+
+        return state.focusMode === 'sections'
+            ? (updateActiveSection(state, state.activeSectionIndex - 1) ? 'rerender' : 'noop')
+            : (updateScroll(state, -1) ? 'rerender' : 'noop');
+
+    }
+    if (key === 'DOWN') {
+
+        return state.focusMode === 'sections'
+            ? (updateActiveSection(state, state.activeSectionIndex + 1) ? 'rerender' : 'noop')
+            : (updateScroll(state, 1) ? 'rerender' : 'noop');
+
+    }
+
+    return 'noop';
+
+}
+
+function enterScreen(): void {
+
+    stdout.write('\x1b[?1049h');
+    stdout.write('\x1b[?25l');
+    stdout.write('\x1b[2J\x1b[H');
+
+}
+
+function leaveScreen(): void {
+
+    stdout.write('\x1b[?25h');
+    stdout.write('\x1b[?1049l');
+
+}
+
+function render(state: InspectTuiState): void {
+
+    stdout.write('\x1b[2J\x1b[H');
+    stdout.write(buildFrame(state));
+
+}
+
+function createState(sections: InspectTuiSection[], options: InspectTuiOptions): InspectTuiState {
+
+    return {
+        sections,
+        activeSectionIndex: 0,
+        scrollOffset: 0,
+        focusMode: 'sections',
+        options,
+        useColor: process.env.NO_COLOR === undefined,
+    };
+
+}
+
+// eslint-disable-next-line max-lines-per-function
+function startTuiSession(state: InspectTuiState, resolve: (value: boolean) => void): void {
+
+    let finished = false;
+
+    function finish(value: boolean): void {
+
+        if (finished) return;
+        finished = true;
+        stdin.removeListener('data', onData);
+        stdout.removeListener('resize', onResize);
+        stdin.setRawMode(false);
+        stdin.pause();
+        leaveScreen();
+        resolve(value);
+
+    }
+
+    function onData(chunk: Buffer|string): void {
+
+        const key = normalizeKey(typeof chunk === 'string' ? chunk : chunk.toString('utf8'));
+        const action = applyKey(state, key);
+
+        if (action === 'quit') {
+
+            finish(true);
+            return;
+
+        }
+
+        if (action === 'rerender') render(state);
+
+    }
+
+    function onResize(): void {
+
+        render(state);
+
+    }
+
+    try {
+
+        enterScreen();
+        stdin.setRawMode(true);
+        stdin.resume();
+        stdin.setEncoding('utf8');
+        stdin.on('data', onData);
+        stdout.on('resize', onResize);
+        render(state);
+
+    } catch {
+
+        finish(false);
+
+    }
+
+}
+
+export async function viewInspectTui(
+    sections: InspectTuiSection[],
+    options: InspectTuiOptions,
+): Promise<boolean> {
+
+    if (!supportsInteractiveTui() || sections.length === 0 || typeof stdin.setRawMode !== 'function') {
+
+        return false;
+
+    }
+
+    const state = createState(sections, options);
+
+    return new Promise((resolve) => startTuiSession(state, resolve));
+
+}


### PR DESCRIPTION
## Summary
- Add an interactive multi-pane TUI for `inspect-stack` with section navigation, content scrolling, and keyboard controls (`Tab`, arrows/hjkl, `PgUp/PgDn`, `g/G`, `q`).
- Keep CI/non-interactive behavior safe by falling back to existing pager/text output when interactive mode is unavailable or disabled.
- Improve inspect content presentation with syntax-like highlighting for key/value lines, timestamps, status tokens, and reason labels.
- Align parameter/output formatting to `Key: Value` style and update CLI/README wording to reflect the interactive pane experience.

## Test plan
- [x] `source ~/.nvm/nvm.sh && nvm use 24 >/dev/null && npm run lint`
- [x] `source ~/.nvm/nvm.sh && nvm use 24 >/dev/null && npm test`
- [x] `source ~/.nvm/nvm.sh && nvm use 24 >/dev/null && npm run build`
- [x] `source ~/.nvm/nvm.sh && nvm use 24 >/dev/null && node ./bin/awscfn inspect-stack --help`