### PR TITLE
fix: restore validate-template and clean preview create leftovers

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,18 @@ If the stack is **`ROLLBACK_COMPLETE`**, **`update-stack`** would delete and rec
 
 Non-resource change-set entries (for example hooks) are counted and noted when they are not shown as table rows.
 
+### ✅ validate-template
+
+Validate a CloudFormation template without creating a change set.
+
+```bash
+awscfn validate-template -t <TEMPLATE_FILE>
+```
+
+| Flag | Description |
+|------|-------------|
+| `--template`, `-t` | CloudFormation template file |
+
 ### ♻️ redeploy-stack
 
 ```bash

--- a/bin/awscfn
+++ b/bin/awscfn
@@ -13,6 +13,8 @@ const { inspectStack } = require('../dist/inspectStack');
 const { previewStack } = require('../dist/previewStack');
 const { redeployStack } = require('../dist/redeployStack');
 const { updateStack } = require('../dist/updateStack');
+const { validateTemplateOrExit } = require('../dist/cli/validateTemplate');
+const { initCloudFormationClient } = require('../dist/lib/cfn');
 const { getOutputConfig, setOutputConfig } = require('../dist/lib/output');
 
 const pkg = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf8'));
@@ -429,6 +431,19 @@ const cli = yargs
     (cmd) => cmd.options({ ...nameOpt, ...templateOpt, ...paramsOpt, ...setOpt }),
     ({ name, template, params, set }) => {
       runCommand(() => previewStack(name, template, params, require('../dist/cli/parseParamOverrides').parseParamOverrides(set).overrides));
+    }
+  )
+  .command(
+    'validate-template',
+    'Validate a CloudFormation template',
+    (cmd) => cmd.options({ ...templateOpt }),
+    ({ template }) => {
+      runCommand(async () => {
+        initCloudFormationClient();
+        const templateBody = fs.readFileSync(template, 'utf8');
+        await validateTemplateOrExit(templateBody);
+        console.log('template is valid');
+      });
     }
   )
   .command(

--- a/src/previewStack.ts
+++ b/src/previewStack.ts
@@ -40,6 +40,37 @@ export async function previewStack(
 
     info(`${symbols.arrow} Preview ${cyan(operation)} for stack ${cyan(stackName)}`);
 
-    await cfn.previewChangeSet(stackName, {body: template, params}, operation);
+    try {
+
+        await cfn.previewChangeSet(stackName, {body: template, params}, operation);
+
+    } finally {
+
+        await cleanupCreatePreviewStack(existing, stackName);
+
+    }
+
+}
+
+async function cleanupCreatePreviewStack(
+    existing: Awaited<ReturnType<typeof cfn.getStackByName>>,
+    stackName: string,
+): Promise<void> {
+
+    if (existing) return;
+
+    const createdForPreview = await cfn.getStackByName(stackName, true);
+
+    if (!createdForPreview || createdForPreview.StackStatus !== StackStatus.REVIEW_IN_PROGRESS) {
+
+        return;
+
+    }
+
+    warn(
+        `Preview created stack ${stackName} in REVIEW_IN_PROGRESS. `
+        + 'Cleaning it up automatically...',
+    );
+    await cfn.deleteStack(createdForPreview);
 
 }


### PR DESCRIPTION
## Summary
- Restore `validate-template` command wiring so it appears in CLI help/completions and works from `awscfn` again.
- Fix `preview-stack` CREATE-mode behavior to automatically clean up temporary `REVIEW_IN_PROGRESS` stacks created during preview.
- Update README command docs to include `validate-template` again.

## Test plan
- [x] `source ~/.nvm/nvm.sh && nvm use 24 >/dev/null && npm run lint`
- [x] `source ~/.nvm/nvm.sh && nvm use 24 >/dev/null && npm run build`
- [x] `source ~/.nvm/nvm.sh && nvm use 24 >/dev/null && node ./bin/awscfn --help`
- [x] `source ~/.nvm/nvm.sh && nvm use 24 >/dev/null && node ./bin/awscfn validate-template --help`