### PR TITLE
feat: add interactive preview deploy prompt and CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
       - main
 jobs:
   ci:
-    name: Build & Lint
+    name: Build, Lint & Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -17,5 +17,7 @@ jobs:
         run: npm ci
       - name: Lint
         run: npm run lint
+      - name: Test
+        run: npm test
       - name: Build
         run: npm run build

--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ awscfn preview-stack -n <STACK_NAME> -t <TEMPLATE_FILE> -p <PARAMS_FILE>
 
 Use this to review Add / Modify / Remove actions (and replacement hints) before running **`create-stack`** or **`update-stack`**.
 
+In interactive terminals, `preview-stack` will prompt to deploy immediately after the preview. In CI/non-interactive mode, no prompt is shown.
+
 If the stack is **`ROLLBACK_COMPLETE`**, **`update-stack`** would delete and recreate it — **`preview-stack` cannot model that path** and exits with an error (delete the stack or run **`update-stack`** first).
 
 Non-resource change-set entries (for example hooks) are counted and noted when they are not shown as table rows.

--- a/bin/awscfn
+++ b/bin/awscfn
@@ -427,7 +427,7 @@ const cli = yargs
   )
   .command(
     'preview-stack',
-    'Preview changes without deploying (change set only)',
+    'Preview changes (interactive deploy prompt in TTY)',
     (cmd) => cmd.options({ ...nameOpt, ...templateOpt, ...paramsOpt, ...setOpt }),
     ({ name, template, params, set }) => {
       runCommand(() => previewStack(name, template, params, require('../dist/cli/parseParamOverrides').parseParamOverrides(set).overrides));

--- a/src/lib/cfn/deleteStack.ts
+++ b/src/lib/cfn/deleteStack.ts
@@ -1,9 +1,19 @@
 import {DeleteStackCommand, Stack} from '@aws-sdk/client-cloudformation';
-import {waitUntilStackTerminal} from './waitUntilStackTerminal';
+import {waitUntilStackTerminalWithEvents} from './waitUntilStackTerminal';
 import {toResultAsync} from '../toResult';
 import {getCfClient} from '.';
 
-export async function deleteStack(stack: Stack): Promise<void> {
+export interface DeleteStackOptions {
+    waitForCompletion?: boolean
+    timeoutMs?: number
+}
+
+export async function deleteStack(
+    stack: Stack,
+    options: DeleteStackOptions = {},
+): Promise<void> {
+
+    const {waitForCompletion = true, timeoutMs} = options;
 
     console.log(`deleting stack ${stack.StackName}...`);
 
@@ -12,7 +22,17 @@ export async function deleteStack(stack: Stack): Promise<void> {
 
     await cf.send(deleteStackCommand);
 
-    const [err] = await toResultAsync(waitUntilStackTerminal(stack.StackName as string));
+    if (!waitForCompletion) {
+
+        console.log(`🗑 delete requested for stack ${stack.StackName} (${stack.StackId})`);
+        return;
+
+    }
+
+    const [err] = await toResultAsync(waitUntilStackTerminalWithEvents(
+        stack.StackName as string,
+        timeoutMs ? {timeoutMs} : {},
+    ));
 
     if (err && err.message !== 'stack not found') throw err;
 

--- a/src/lib/cfn/executeChangeSet.ts
+++ b/src/lib/cfn/executeChangeSet.ts
@@ -7,6 +7,9 @@ import {Template, TemplateParams, getCfClient} from './index';
 import {dim, getOutputConfig, gray, startSpinner, symbols} from '../output';
 
 export type ChangeSetOperation = 'UPDATE' | 'CREATE';
+export interface SubmitChangeSetOptions {
+    clientToken?: string
+}
 
 function hasParams<P extends TemplateParams>(template: Template<P>): boolean {
 
@@ -33,6 +36,7 @@ export async function submitChangeSetRequest<P extends TemplateParams>(
     stackName: string,
     template: Template<P>,
     operation: ChangeSetOperation,
+    options: SubmitChangeSetOptions = {},
 ): Promise<string> {
 
     const cf = getCfClient();
@@ -49,6 +53,7 @@ export async function submitChangeSetRequest<P extends TemplateParams>(
         ChangeSetType: operation,
         Parameters: parameters,
         Capabilities: ['CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
+        ClientToken: options.clientToken,
     }));
 
     return changeset.Id as string;

--- a/src/lib/cfn/getStackByName.ts
+++ b/src/lib/cfn/getStackByName.ts
@@ -4,7 +4,7 @@ import {getCfClient} from '.';
 
 export async function getStackByName(name: string, suppressLog: boolean = false): Promise<Stack|undefined> {
 
-    !suppressLog && console.log(`looking up stack ${name}`);
+    !suppressLog && console.log(`looking up stack "${name}"`);
 
     const cf = getCfClient();
     const [error, result] = await toResultAsync(cf.send(new DescribeStacksCommand({StackName: name})));
@@ -25,7 +25,7 @@ export async function getStackByName(name: string, suppressLog: boolean = false)
 
     if (stack) {
 
-        !suppressLog && console.log(`found stack ${name} as ${stack.StackId}`);
+        !suppressLog && console.log(`found stack "${name}" as ${stack.StackId}`);
         return stack;
 
     }

--- a/src/lib/cfn/previewChangeSet.ts
+++ b/src/lib/cfn/previewChangeSet.ts
@@ -9,9 +9,16 @@ import {
     submitChangeSetRequest,
     waitForChangeSetBuild,
     type ChangeSetOperation,
+    type SubmitChangeSetOptions,
 } from './executeChangeSet';
 import {Template, TemplateParams, getCfClient} from './index';
 import {cyan, dim, gray, info, success, symbols} from '../output';
+
+export interface PreviewChangeSetOptions extends SubmitChangeSetOptions {}
+export interface PreviewChangeSetResult {
+    previewStackId?: string
+}
+type PreviewError = Error & { previewStackId?: string };
 
 function isNoChangesOutcome(desc: DescribeChangeSetOutput): boolean {
 
@@ -91,29 +98,71 @@ function printPlannedTable(stackName: string, desc: DescribeChangeSetOutput): vo
 
 }
 
-/** Fetch full change list after the SDK waiter finished building the change set (waiter polls status only). */
-async function runPreviewFromBuiltChangeSet(
-    stackName: string,
-    changeSetId: string,
-): Promise<void> {
+function toPreviewError(
+    original: unknown,
+    detail: string,
+    previewStackId?: string,
+): PreviewError {
 
-    const desc = await describeChangeSetPaginated(changeSetId);
+    const error = original instanceof Error
+        ? original
+        : new Error(detail, {cause: original});
+
+    error.message = `${detail}${original instanceof Error ? ` — ${original.message}` : ''}`;
+
+    (error as PreviewError).previewStackId = previewStackId;
+
+    return error as PreviewError;
+
+}
+
+async function waitForPreviewDescription(
+    changeSetId: string,
+): Promise<DescribeChangeSetOutput> {
+
+    try {
+
+        await waitForChangeSetBuild(changeSetId);
+
+    } catch (waitErr) {
+
+        const descEarly = await describeChangeSetPaginated(changeSetId);
+
+        if (isNoChangesOutcome(descEarly)) return descEarly;
+
+        const detail = descEarly.StatusReason ?? 'Change set did not complete successfully';
+
+        throw toPreviewError(waitErr, detail, descEarly.StackId);
+
+    }
+
+    return describeChangeSetPaginated(changeSetId);
+
+}
+
+function finalizePreviewResult(
+    stackName: string,
+    desc: DescribeChangeSetOutput,
+): PreviewChangeSetResult {
 
     if (isNoChangesOutcome(desc)) {
 
         success(`${symbols.check} Stack ${cyan(stackName)} — no changes to apply`);
-
-        return;
+        return {previewStackId: desc.StackId};
 
     }
 
     if (desc.Status !== 'CREATE_COMPLETE') {
 
-        throw new Error(desc.StatusReason ?? `Change set status: ${desc.Status ?? 'unknown'}`);
+        const detail = desc.StatusReason ?? `Change set status: ${desc.Status ?? 'unknown'}`;
+
+        throw toPreviewError(new Error(detail), detail, desc.StackId);
 
     }
 
     printPlannedTable(stackName, desc);
+
+    return {previewStackId: desc.StackId};
 
 }
 
@@ -124,44 +173,18 @@ export async function previewChangeSet<P extends TemplateParams>(
     stackName: string,
     template: Template<P>,
     operation: ChangeSetOperation,
-): Promise<void> {
+    options: PreviewChangeSetOptions = {},
+): Promise<PreviewChangeSetResult> {
 
     dim(`  ${symbols.bullet} Building change set ${gray(`(${operation.toLowerCase()} preview)`)}`);
 
-    const changeSetId = await submitChangeSetRequest(stackName, template, operation);
+    const changeSetId = await submitChangeSetRequest(stackName, template, operation, options);
 
     try {
 
-        try {
+        const desc = await waitForPreviewDescription(changeSetId);
 
-            await waitForChangeSetBuild(changeSetId);
-
-        } catch (waitErr) {
-
-            const descEarly = await describeChangeSetPaginated(changeSetId);
-
-            if (isNoChangesOutcome(descEarly)) {
-
-                success(`${symbols.check} Stack ${cyan(stackName)} — no changes to apply`);
-
-                return;
-
-            }
-
-            const detail = descEarly.StatusReason ?? 'Change set did not complete successfully';
-
-            if (waitErr instanceof Error) {
-
-                waitErr.message = `${detail} — ${waitErr.message}`;
-                throw waitErr;
-
-            }
-
-            throw new Error(detail, {cause: waitErr});
-
-        }
-
-        await runPreviewFromBuiltChangeSet(stackName, changeSetId);
+        return finalizePreviewResult(stackName, desc);
 
     } finally {
 

--- a/src/previewStack.ts
+++ b/src/previewStack.ts
@@ -1,3 +1,4 @@
+import {randomUUID} from 'node:crypto';
 import {stdin, stdout} from 'node:process';
 import {createInterface} from 'node:readline/promises';
 import {StackStatus} from '@aws-sdk/client-cloudformation';
@@ -11,6 +12,7 @@ const PREVIEW_DELETE_WAIT_TIMEOUT_MS = 2 * 60 * 1000;
 const PREVIEW_DELETE_POLL_MS = 3000;
 
 type ExistingStack = Awaited<ReturnType<typeof cfn.getStackByName>>;
+type PreviewChangeSetError = Error & { previewStackId?: string };
 
 /**
  * CLI: preview stack changes without executing (build change set, print table, delete change set).
@@ -27,9 +29,10 @@ export async function previewStack(
 
     const {template, params} = await loadTemplateAndParams(templatePath, paramsPath, overrides);
     const existing = await cfn.getStackByName(stackName);
+    const previewRunId = createPreviewRunId();
 
     await ensurePreviewable(stackName, template, existing);
-    await previewThenMaybeDeploy(stackName, template, params, existing);
+    await previewThenMaybeDeploy(stackName, template, params, existing, previewRunId);
 
 }
 
@@ -38,13 +41,26 @@ async function previewThenMaybeDeploy(
     template: string,
     params: Record<string, unknown>,
     existing: ExistingStack,
+    previewRunId: string,
 ): Promise<void> {
 
-    await runPreviewChangeSet(stackName, template, params, existing);
+    const previewStackId = await runPreviewChangeSet(
+        stackName,
+        template,
+        params,
+        existing,
+        previewRunId,
+    );
 
     const shouldDeploy = await promptDeployAfterPreview(stackName);
 
-    await cleanupCreatePreviewStackBestEffort(existing, stackName, shouldDeploy);
+    await cleanupCreatePreviewStackBestEffort(
+        existing,
+        stackName,
+        shouldDeploy,
+        previewStackId,
+        previewRunId,
+    );
 
     if (!shouldDeploy) return;
 
@@ -58,7 +74,8 @@ async function runPreviewChangeSet(
     template: string,
     params: Record<string, unknown>,
     existing: ExistingStack,
-): Promise<void> {
+    previewRunId: string,
+): Promise<string|undefined> {
 
     const operation = existing ? 'UPDATE' : 'CREATE';
 
@@ -66,11 +83,27 @@ async function runPreviewChangeSet(
 
     try {
 
-        await cfn.previewChangeSet(stackName, {body: template, params}, operation);
+        const previewResult = await cfn.previewChangeSet(
+            stackName,
+            {body: template, params},
+            operation,
+            {clientToken: previewRunId},
+        );
+
+        return previewResult.previewStackId;
 
     } catch (error) {
 
-        await cleanupCreatePreviewStackBestEffort(existing, stackName, false);
+        const previewStackId = getPreviewStackIdFromError(error)
+            ?? await resolvePreviewStackId(existing, stackName);
+
+        await cleanupCreatePreviewStackBestEffort(
+            existing,
+            stackName,
+            false,
+            previewStackId,
+            previewRunId,
+        );
         throw error;
 
     }
@@ -105,11 +138,19 @@ async function cleanupCreatePreviewStackBestEffort(
     existing: ExistingStack,
     stackName: string,
     waitForCompletion: boolean,
+    expectedStackId?: string,
+    previewRunId?: string,
 ): Promise<void> {
 
     try {
 
-        await cleanupCreatePreviewStack(existing, stackName, waitForCompletion);
+        await cleanupCreatePreviewStack(
+            existing,
+            stackName,
+            waitForCompletion,
+            expectedStackId,
+            previewRunId,
+        );
 
     } catch (error) {
 
@@ -125,11 +166,14 @@ async function cleanupCreatePreviewStack(
     existing: ExistingStack,
     stackName: string,
     waitForCompletion: boolean,
+    expectedStackId?: string,
+    previewRunId?: string,
 ): Promise<void> {
 
-    if (existing) return;
+    if (shouldSkipPreviewCleanup(existing, stackName, expectedStackId, previewRunId)) return;
 
-    const createdForPreview = await cfn.getStackByName(stackName, true);
+    const verifiedStackId = expectedStackId as string;
+    const createdForPreview = await getOwnedPreviewStackForCleanup(stackName, verifiedStackId);
 
     if (!createdForPreview) return;
 
@@ -155,13 +199,57 @@ async function cleanupCreatePreviewStack(
 
     if (waitForCompletion) {
 
-        await waitForPreviewDeletion(stackName);
+        await waitForPreviewDeletion(stackName, verifiedStackId);
 
     }
 
 }
 
-async function waitForPreviewDeletion(stackName: string): Promise<void> {
+function shouldSkipPreviewCleanup(
+    existing: ExistingStack,
+    stackName: string,
+    expectedStackId?: string,
+    previewRunId?: string,
+): boolean {
+
+    if (existing) return true;
+
+    if (expectedStackId) return false;
+
+    warn(
+        `Skipping automatic preview cleanup for stack "${stackName}" `
+        + `${previewRunId ? `(run ${previewRunId.slice(0, 8)}) ` : ''}`
+        + 'because ownership could not be verified.',
+    );
+
+    return true;
+
+}
+
+async function getOwnedPreviewStackForCleanup(
+    stackName: string,
+    expectedStackId: string,
+): Promise<NonNullable<ExistingStack>|undefined> {
+
+    const createdForPreview = await cfn.getStackByName(stackName, true);
+
+    if (!createdForPreview) return undefined;
+
+    if (isOwnedPreviewStack(createdForPreview, expectedStackId)) return createdForPreview;
+
+    warn(
+        `Skipping automatic preview cleanup for stack "${stackName}" `
+        + 'because stack identity changed.',
+    );
+
+    return undefined;
+
+}
+
+async function waitForPreviewDeletion(
+    stackName: string,
+    expectedStackId: string,
+): Promise<void> {
 
     const startedAt = Date.now();
 
@@ -171,6 +259,16 @@ async function waitForPreviewDeletion(stackName: string): Promise<void> {
 
         if (!current) return;
 
+        if (!isOwnedPreviewStack(current, expectedStackId)) {
+
+            warn(
+                `Stopping preview cleanup wait for stack "${stackName}" `
+                + 'because stack identity changed.',
+            );
+            return;
+
+        }
+
         await new Promise((resolve) => setTimeout(resolve, PREVIEW_DELETE_POLL_MS));
 
     }
@@ -179,6 +277,40 @@ async function waitForPreviewDeletion(stackName: string): Promise<void> {
         `Timed out waiting for preview cleanup to delete stack "${stackName}". `
         + 'Try again in a minute.',
     );
+
+}
+
+function createPreviewRunId(): string {
+
+    return randomUUID();
+
+}
+
+function getPreviewStackIdFromError(error: unknown): string|undefined {
+
+    return (error as PreviewChangeSetError)?.previewStackId;
+
+}
+
+async function resolvePreviewStackId(
+    existing: ExistingStack,
+    stackName: string,
+): Promise<string|undefined> {
+
+    if (existing) return undefined;
+
+    const createdForPreview = await cfn.getStackByName(stackName, true);
+
+    return createdForPreview?.StackId;
+
+}
+
+function isOwnedPreviewStack(
+    stack: NonNullable<ExistingStack>,
+    expectedStackId: string,
+): boolean {
+
+    return stack.StackId === expectedStackId;
 
 }
 

--- a/src/previewStack.ts
+++ b/src/previewStack.ts
@@ -1,8 +1,16 @@
+import {stdin, stdout} from 'node:process';
+import {createInterface} from 'node:readline/promises';
 import {StackStatus} from '@aws-sdk/client-cloudformation';
 import * as cfn from './lib/cfn';
+import {logStackAction} from './cli/log';
 import {loadTemplateAndParams} from './cli/loadTemplateAndParams';
 import {validateTemplateOrExit} from './cli/validateTemplate';
 import {cyan, info, symbols, warn} from './lib/output';
+
+const PREVIEW_DELETE_WAIT_TIMEOUT_MS = 2 * 60 * 1000;
+const PREVIEW_DELETE_POLL_MS = 3000;
+
+type ExistingStack = Awaited<ReturnType<typeof cfn.getStackByName>>;
 
 /**
  * CLI: preview stack changes without executing (build change set, print table, delete change set).
@@ -20,6 +28,61 @@ export async function previewStack(
     const {template, params} = await loadTemplateAndParams(templatePath, paramsPath, overrides);
     const existing = await cfn.getStackByName(stackName);
 
+    await ensurePreviewable(stackName, template, existing);
+    await previewThenMaybeDeploy(stackName, template, params, existing);
+
+}
+
+async function previewThenMaybeDeploy(
+    stackName: string,
+    template: string,
+    params: Record<string, unknown>,
+    existing: ExistingStack,
+): Promise<void> {
+
+    await runPreviewChangeSet(stackName, template, params, existing);
+
+    const shouldDeploy = await promptDeployAfterPreview(stackName);
+
+    await cleanupCreatePreviewStackBestEffort(existing, stackName, shouldDeploy);
+
+    if (!shouldDeploy) return;
+
+    info(`${symbols.arrow} Deploying stack ${cyan(stackName)} from preview...`);
+    await deployPreview(stackName, template, params);
+
+}
+
+async function runPreviewChangeSet(
+    stackName: string,
+    template: string,
+    params: Record<string, unknown>,
+    existing: ExistingStack,
+): Promise<void> {
+
+    const operation = existing ? 'UPDATE' : 'CREATE';
+
+    info(`${symbols.arrow} Preview ${cyan(operation)} for stack ${cyan(stackName)}`);
+
+    try {
+
+        await cfn.previewChangeSet(stackName, {body: template, params}, operation);
+
+    } catch (error) {
+
+        await cleanupCreatePreviewStackBestEffort(existing, stackName, false);
+        throw error;
+
+    }
+
+}
+
+async function ensurePreviewable(
+    stackName: string,
+    template: string,
+    existing: ExistingStack,
+): Promise<void> {
+
     if (existing?.StackStatus === StackStatus.ROLLBACK_COMPLETE) {
 
         warn(
@@ -36,41 +99,138 @@ export async function previewStack(
     console.log('validating template...');
     await validateTemplateOrExit(template);
 
-    const operation = existing ? 'UPDATE' : 'CREATE';
+}
 
-    info(`${symbols.arrow} Preview ${cyan(operation)} for stack ${cyan(stackName)}`);
+async function cleanupCreatePreviewStackBestEffort(
+    existing: ExistingStack,
+    stackName: string,
+    waitForCompletion: boolean,
+): Promise<void> {
 
     try {
 
-        await cfn.previewChangeSet(stackName, {body: template, params}, operation);
+        await cleanupCreatePreviewStack(existing, stackName, waitForCompletion);
 
-    } finally {
+    } catch (error) {
 
-        await cleanupCreatePreviewStack(existing, stackName);
+        const message = error instanceof Error ? error.message : String(error);
+
+        warn(`Could not fully clean preview stack "${stackName}": ${message}`);
 
     }
 
 }
 
 async function cleanupCreatePreviewStack(
-    existing: Awaited<ReturnType<typeof cfn.getStackByName>>,
+    existing: ExistingStack,
     stackName: string,
+    waitForCompletion: boolean,
 ): Promise<void> {
 
     if (existing) return;
 
     const createdForPreview = await cfn.getStackByName(stackName, true);
 
-    if (!createdForPreview || createdForPreview.StackStatus !== StackStatus.REVIEW_IN_PROGRESS) {
+    if (!createdForPreview) return;
+
+    const status = createdForPreview.StackStatus as StackStatus|undefined;
+    const needsDelete = status === StackStatus.REVIEW_IN_PROGRESS;
+    const alreadyDeleting = status === StackStatus.DELETE_IN_PROGRESS;
+
+    if (!needsDelete && !alreadyDeleting) {
 
         return;
 
     }
 
-    warn(
-        `Preview created stack ${stackName} in REVIEW_IN_PROGRESS. `
-        + 'Cleaning it up automatically...',
+    if (needsDelete) {
+
+        warn(
+            `Preview created stack ${stackName} in REVIEW_IN_PROGRESS. `
+            + 'Cleaning it up automatically...',
+        );
+        await cfn.deleteStack(createdForPreview, {waitForCompletion: false});
+
+    }
+
+    if (waitForCompletion) {
+
+        await waitForPreviewDeletion(stackName);
+
+    }
+
+}
+
+async function waitForPreviewDeletion(stackName: string): Promise<void> {
+
+    const startedAt = Date.now();
+
+    while (Date.now() - startedAt < PREVIEW_DELETE_WAIT_TIMEOUT_MS) {
+
+        const current = await cfn.getStackByName(stackName, true);
+
+        if (!current) return;
+
+        await new Promise((resolve) => setTimeout(resolve, PREVIEW_DELETE_POLL_MS));
+
+    }
+
+    throw new Error(
+        `Timed out waiting for preview cleanup to delete stack "${stackName}". `
+        + 'Try again in a minute.',
     );
-    await cfn.deleteStack(createdForPreview);
+
+}
+
+function canPromptInteractively(): boolean {
+
+    return stdin.isTTY === true
+        && stdout.isTTY === true
+        && process.env.CI !== 'true'
+        && process.env.GITHUB_ACTIONS !== 'true';
+
+}
+
+async function promptDeployAfterPreview(stackName: string): Promise<boolean> {
+
+    if (!canPromptInteractively()) return false;
+
+    const rl = createInterface({input: stdin, output: stdout});
+
+    try {
+
+        const answer = (await rl.question(
+            `Deploy stack "${stackName}" now using update/create flow? [y/N] `,
+        )).trim().toLowerCase();
+
+        return answer === 'y' || answer === 'yes';
+
+    } finally {
+
+        rl.close();
+
+    }
+
+}
+
+async function deployPreview(
+    stackName: string,
+    template: string,
+    params: Record<string, unknown>,
+): Promise<void> {
+
+    const latest = await cfn.getStackByName(stackName, true);
+
+    if (!latest) {
+
+        logStackAction(stackName, 'creating', params);
+        await cfn.createStack(stackName, {body: template, params});
+
+        return;
+
+    }
+
+    logStackAction(stackName, 'updating', params);
+    await cfn.updateStack(latest, {body: template, params});
 
 }


### PR DESCRIPTION
## Summary
- add an interactive post-preview prompt in `preview-stack` (TTY only) to optionally deploy immediately using create/update flow
- harden preview cleanup to avoid hangs by allowing non-blocking delete for preview-created `REVIEW_IN_PROGRESS` stacks and bounded wait handling before deploy
- improve CLI/docs for the new preview behavior and quote stack names in lookup logs for clearer output
- run unit tests in PR CI by adding an explicit `npm test` step to `.github/workflows/ci.yml`

## Test plan
- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run build`
- [x] `npm run validate`