### PR TITLE
feat: execute reviewed preview change set on confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ If there are no changes to apply, the command succeeds gracefully:
 
 ### 👁️ preview-stack
 
-Builds a change set (same capabilities as deploy), prints a **table of planned resource-level changes**, then **deletes** the change set without executing it. If the stack exists, uses an **UPDATE** change set; otherwise **CREATE**.
+Builds a change set (same capabilities as deploy), prints a **table of planned resource-level changes**, then leaves it unexecuted by default. If the stack exists, uses an **UPDATE** change set; otherwise **CREATE**.
 
 ```bash
 awscfn preview-stack -n <STACK_NAME> -t <TEMPLATE_FILE> -p <PARAMS_FILE>
@@ -176,7 +176,7 @@ awscfn preview-stack -n <STACK_NAME> -t <TEMPLATE_FILE> -p <PARAMS_FILE>
 
 Use this to review Add / Modify / Remove actions (and replacement hints) before running **`create-stack`** or **`update-stack`**.
 
-In interactive terminals, `preview-stack` will prompt to deploy immediately after the preview. In CI/non-interactive mode, no prompt is shown.
+In interactive terminals, `preview-stack` will prompt to deploy immediately after the preview. If you answer `yes`, it executes the **same reviewed change set** (with ownership/status checks) instead of rebuilding a new one. In CI/non-interactive mode, no prompt is shown.
 
 If the stack is **`ROLLBACK_COMPLETE`**, **`update-stack`** would delete and recreate it — **`preview-stack` cannot model that path** and exits with an error (delete the stack or run **`update-stack`** first).
 

--- a/src/lib/cfn/executeChangeSet.ts
+++ b/src/lib/cfn/executeChangeSet.ts
@@ -108,15 +108,22 @@ export async function createAndExecChangeSet<P extends TemplateParams>(
 
     dim(`  ${symbols.bullet} Creating changeset ${gray(`(${operation.toLowerCase()})`)}`);
 
-    const cf = getCfClient();
     const changeSetId = await createChangeSetAndWait(stackName, template, operation);
 
     dim(`  ${symbols.bullet} Executing changeset...`);
 
+    await executeExistingChangeSet(changeSetId);
+
+    return changeSetId;
+
+}
+
+export async function executeExistingChangeSet(changeSetId: string): Promise<void> {
+
+    const cf = getCfClient();
+
     await cf.send(new ExecuteChangeSetCommand({
         ChangeSetName: changeSetId,
     }));
-
-    return changeSetId;
 
 }

--- a/src/lib/cfn/index.ts
+++ b/src/lib/cfn/index.ts
@@ -36,3 +36,4 @@ export * from './getParamFromStack';
 export * from './streamStackEvents';
 export * from './getStackTemplate';
 export * from './listStackEvents';
+export * from './executeChangeSet';

--- a/src/lib/cfn/previewChangeSet.ts
+++ b/src/lib/cfn/previewChangeSet.ts
@@ -16,9 +16,11 @@ import {cyan, dim, gray, info, success, symbols} from '../output';
 
 export interface PreviewChangeSetOptions extends SubmitChangeSetOptions {}
 export interface PreviewChangeSetResult {
+    changeSetId: string
     previewStackId?: string
 }
 type PreviewError = Error & { previewStackId?: string };
+type PreviewErrorWithChangeSet = PreviewError & { changeSetId?: string };
 
 function isNoChangesOutcome(desc: DescribeChangeSetOutput): boolean {
 
@@ -60,7 +62,7 @@ async function describeChangeSetPaginated(changeSetId: string): Promise<Describe
 
 }
 
-async function deleteChangeSetQuiet(changeSetId: string): Promise<void> {
+export async function deletePreviewChangeSet(changeSetId: string): Promise<void> {
 
     const cf = getCfClient();
 
@@ -75,6 +77,12 @@ async function deleteChangeSetQuiet(changeSetId: string): Promise<void> {
         // Best-effort cleanup after preview
 
     }
+
+}
+
+export async function describePreviewChangeSet(changeSetId: string): Promise<DescribeChangeSetOutput> {
+
+    return describeChangeSetPaginated(changeSetId);
 
 }
 
@@ -116,6 +124,18 @@ function toPreviewError(
 
 }
 
+function withChangeSetId(error: unknown, changeSetId: string): PreviewErrorWithChangeSet {
+
+    const normalized = error instanceof Error
+        ? error as PreviewErrorWithChangeSet
+        : new Error(String(error)) as PreviewErrorWithChangeSet;
+
+    normalized.changeSetId = changeSetId;
+
+    return normalized;
+
+}
+
 async function waitForPreviewDescription(
     changeSetId: string,
 ): Promise<DescribeChangeSetOutput> {
@@ -143,12 +163,13 @@ async function waitForPreviewDescription(
 function finalizePreviewResult(
     stackName: string,
     desc: DescribeChangeSetOutput,
+    changeSetId: string,
 ): PreviewChangeSetResult {
 
     if (isNoChangesOutcome(desc)) {
 
         success(`${symbols.check} Stack ${cyan(stackName)} — no changes to apply`);
-        return {previewStackId: desc.StackId};
+        return {changeSetId, previewStackId: desc.StackId};
 
     }
 
@@ -162,33 +183,47 @@ function finalizePreviewResult(
 
     printPlannedTable(stackName, desc);
 
-    return {previewStackId: desc.StackId};
+    return {changeSetId, previewStackId: desc.StackId};
 
 }
 
 /**
- * Build a change set, print planned resource changes (without executing), then delete the change set.
+ * Build a change set and print planned resource changes without executing.
+ * The change set is deleted only when deleteAfterPreview is true (default).
  */
 export async function previewChangeSet<P extends TemplateParams>(
     stackName: string,
     template: Template<P>,
     operation: ChangeSetOperation,
-    options: PreviewChangeSetOptions = {},
+    options: PreviewChangeSetOptions & { deleteAfterPreview?: boolean } = {},
 ): Promise<PreviewChangeSetResult> {
 
     dim(`  ${symbols.bullet} Building change set ${gray(`(${operation.toLowerCase()} preview)`)}`);
 
+    const {deleteAfterPreview = true} = options;
     const changeSetId = await submitChangeSetRequest(stackName, template, operation, options);
 
     try {
 
-        const desc = await waitForPreviewDescription(changeSetId);
+        try {
 
-        return finalizePreviewResult(stackName, desc);
+            const desc = await waitForPreviewDescription(changeSetId);
+
+            return finalizePreviewResult(stackName, desc, changeSetId);
+
+        } catch (error) {
+
+            throw withChangeSetId(error, changeSetId);
+
+        }
 
     } finally {
 
-        await deleteChangeSetQuiet(changeSetId);
+        if (deleteAfterPreview) {
+
+            await deletePreviewChangeSet(changeSetId);
+
+        }
 
     }
 

--- a/src/previewStack.ts
+++ b/src/previewStack.ts
@@ -1,18 +1,33 @@
 import {randomUUID} from 'node:crypto';
 import {stdin, stdout} from 'node:process';
 import {createInterface} from 'node:readline/promises';
-import {StackStatus} from '@aws-sdk/client-cloudformation';
+import {DescribeChangeSetOutput, StackStatus} from '@aws-sdk/client-cloudformation';
 import * as cfn from './lib/cfn';
 import {logStackAction} from './cli/log';
 import {loadTemplateAndParams} from './cli/loadTemplateAndParams';
 import {validateTemplateOrExit} from './cli/validateTemplate';
-import {cyan, info, symbols, warn} from './lib/output';
+import {cyan, info, success, symbols, warn} from './lib/output';
 
 const PREVIEW_DELETE_WAIT_TIMEOUT_MS = 2 * 60 * 1000;
 const PREVIEW_DELETE_POLL_MS = 3000;
 
 type ExistingStack = Awaited<ReturnType<typeof cfn.getStackByName>>;
-type PreviewChangeSetError = Error & { previewStackId?: string };
+type PreviewChangeSetError = Error & { previewStackId?: string; changeSetId?: string };
+type PreviewOperation = 'CREATE' | 'UPDATE';
+interface PreviewSession {
+    operation: PreviewOperation
+    keepChangeSet: boolean
+    changeSetId?: string
+    previewStackId?: string
+}
+interface RunPreviewInput {
+    stackName: string
+    template: string
+    params: Record<string, unknown>
+    existing: ExistingStack
+    previewRunId: string
+    keepChangeSet: boolean
+}
 
 /**
  * CLI: preview stack changes without executing (build change set, print table, delete change set).
@@ -44,40 +59,41 @@ async function previewThenMaybeDeploy(
     previewRunId: string,
 ): Promise<void> {
 
-    const previewStackId = await runPreviewChangeSet(
+    const keepChangeSet = canPromptInteractively();
+    const previewSession = await runPreviewChangeSet({
         stackName,
         template,
         params,
         existing,
         previewRunId,
-    );
+        keepChangeSet,
+    });
 
     const shouldDeploy = await promptDeployAfterPreview(stackName);
 
-    await cleanupCreatePreviewStackBestEffort(
-        existing,
-        stackName,
-        shouldDeploy,
-        previewStackId,
-        previewRunId,
-    );
+    if (!shouldDeploy) {
 
-    if (!shouldDeploy) return;
+        await cleanupPreviewArtifacts(existing, stackName, previewSession, previewRunId, shouldDeploy);
+        return;
 
-    info(`${symbols.arrow} Deploying stack ${cyan(stackName)} from preview...`);
-    await deployPreview(stackName, template, params);
+    }
+
+    await deployFromPreview(stackName, template, params, previewSession);
 
 }
 
-async function runPreviewChangeSet(
-    stackName: string,
-    template: string,
-    params: Record<string, unknown>,
-    existing: ExistingStack,
-    previewRunId: string,
-): Promise<string|undefined> {
+async function runPreviewChangeSet(input: RunPreviewInput): Promise<PreviewSession> {
 
-    const operation = existing ? 'UPDATE' : 'CREATE';
+    const {
+        stackName,
+        template,
+        params,
+        existing,
+        previewRunId,
+        keepChangeSet,
+    } = input;
+
+    const operation: PreviewOperation = existing ? 'UPDATE' : 'CREATE';
 
     info(`${symbols.arrow} Preview ${cyan(operation)} for stack ${cyan(stackName)}`);
 
@@ -87,26 +103,207 @@ async function runPreviewChangeSet(
             stackName,
             {body: template, params},
             operation,
-            {clientToken: previewRunId},
+            {clientToken: previewRunId, deleteAfterPreview: !keepChangeSet},
         );
 
-        return previewResult.previewStackId;
+        return {
+            operation,
+            keepChangeSet,
+            changeSetId: previewResult.changeSetId,
+            previewStackId: previewResult.previewStackId,
+        };
 
     } catch (error) {
 
-        const previewStackId = getPreviewStackIdFromError(error)
-            ?? await resolvePreviewStackId(existing, stackName);
-
-        await cleanupCreatePreviewStackBestEffort(
-            existing,
-            stackName,
-            false,
-            previewStackId,
-            previewRunId,
-        );
+        await handlePreviewChangeSetError(error, existing, stackName, previewRunId, keepChangeSet);
         throw error;
 
     }
+
+}
+
+async function handlePreviewChangeSetError(
+    error: unknown,
+    existing: ExistingStack,
+    stackName: string,
+    previewRunId: string,
+    keepChangeSet: boolean,
+): Promise<void> {
+
+    const previewStackId = getPreviewStackIdFromError(error)
+        ?? await resolvePreviewStackId(existing, stackName);
+    const changeSetId = getChangeSetIdFromError(error);
+
+    if (keepChangeSet && changeSetId) await cleanupChangeSetBestEffort(changeSetId);
+
+    await cleanupCreatePreviewStackBestEffort(
+        existing,
+        stackName,
+        false,
+        previewStackId,
+        previewRunId,
+    );
+
+}
+
+async function deployFromPreview(
+    stackName: string,
+    template: string,
+    params: Record<string, unknown>,
+    previewSession: PreviewSession,
+): Promise<void> {
+
+    info(`${symbols.arrow} Deploying stack ${cyan(stackName)} from preview...`);
+
+    if (!previewSession.changeSetId) {
+
+        await deployPreview(stackName, template, params);
+        return;
+
+    }
+
+    await executeReviewedPreviewChangeSet(stackName, previewSession);
+
+}
+
+async function cleanupPreviewArtifacts(
+    existing: ExistingStack,
+    stackName: string,
+    previewSession: PreviewSession,
+    previewRunId: string,
+    waitForCompletion: boolean,
+): Promise<void> {
+
+    if (previewSession.keepChangeSet && previewSession.changeSetId) {
+
+        await cleanupChangeSetBestEffort(previewSession.changeSetId);
+
+    }
+
+    await cleanupCreatePreviewStackBestEffort(
+        existing,
+        stackName,
+        waitForCompletion,
+        previewSession.previewStackId,
+        previewRunId,
+    );
+
+}
+
+async function cleanupChangeSetBestEffort(changeSetId: string): Promise<void> {
+
+    try {
+
+        await cfn.deletePreviewChangeSet(changeSetId);
+
+    } catch {
+
+        // best effort cleanup when user declines deploy
+
+    }
+
+}
+
+async function executeReviewedPreviewChangeSet(
+    stackName: string,
+    previewSession: PreviewSession,
+): Promise<void> {
+
+    const desc = await cfn.describePreviewChangeSet(previewSession.changeSetId as string);
+
+    if (isNoChangesChangeSet(desc)) {
+
+        await handleNoChangesPreviewExecution(stackName, previewSession);
+        return;
+
+    }
+
+    ensurePreviewChangeSetIsExecutable(stackName, previewSession, desc);
+
+    await cfn.executeExistingChangeSet(previewSession.changeSetId as string);
+
+    const terminal = await cfn.waitUntilStackTerminalWithEvents(stackName);
+
+    if (!isExpectedDeployTerminalStatus(previewSession.operation, terminal.stack.StackStatus as StackStatus)) {
+
+        const reason = terminal.failureReason ? ` Reason: ${terminal.failureReason}` : '';
+
+        throw new Error(
+            `Preview deploy did not complete successfully for stack "${stackName}". `
+            + `Final status: ${terminal.stack.StackStatus}.${reason}`,
+        );
+
+    }
+
+    const verb = previewSession.operation === 'CREATE' ? 'created' : 'updated';
+
+    success(`${symbols.check} Stack ${cyan(stackName)} ${verb} successfully from reviewed preview`);
+
+}
+
+async function handleNoChangesPreviewExecution(
+    stackName: string,
+    previewSession: PreviewSession,
+): Promise<void> {
+
+    success(`${symbols.check} Stack ${cyan(stackName)} is up to date (no changes)`);
+    await cleanupChangeSetBestEffort(previewSession.changeSetId as string);
+
+    if (previewSession.operation !== 'CREATE') return;
+
+    await cleanupCreatePreviewStackBestEffort(
+        undefined,
+        stackName,
+        false,
+        previewSession.previewStackId,
+    );
+
+}
+
+function ensurePreviewChangeSetIsExecutable(
+    stackName: string,
+    previewSession: PreviewSession,
+    desc: DescribeChangeSetOutput,
+): void {
+
+    if (previewSession.previewStackId && desc.StackId !== previewSession.previewStackId) {
+
+        throw new Error(
+            `Preview change set ownership mismatch for stack "${stackName}". `
+            + 'Refusing to execute a different stack identity.',
+        );
+
+    }
+
+    if (desc.Status !== 'CREATE_COMPLETE' || desc.ExecutionStatus !== 'AVAILABLE') {
+
+        throw new Error(
+            `Preview change set is not executable for stack "${stackName}". `
+            + `Status: ${desc.Status ?? 'unknown'}, execution: ${desc.ExecutionStatus ?? 'unknown'}.`,
+        );
+
+    }
+
+}
+
+function isNoChangesChangeSet(desc: DescribeChangeSetOutput): boolean {
+
+    const reason = desc.StatusReason ?? '';
+
+    return Boolean(desc.Status === 'FAILED'
+        && (reason.includes('didn\'t contain changes')
+            || reason.includes('No updates are to be performed')));
+
+}
+
+function isExpectedDeployTerminalStatus(
+    operation: PreviewOperation,
+    status: StackStatus,
+): boolean {
+
+    if (operation === 'CREATE') return status === StackStatus.CREATE_COMPLETE;
+
+    return status === StackStatus.UPDATE_COMPLETE;
 
 }
 
@@ -289,6 +486,12 @@ function createPreviewRunId(): string {
 function getPreviewStackIdFromError(error: unknown): string|undefined {
 
     return (error as PreviewChangeSetError)?.previewStackId;
+
+}
+
+function getChangeSetIdFromError(error: unknown): string|undefined {
+
+    return (error as PreviewChangeSetError)?.changeSetId;
 
 }
 


### PR DESCRIPTION
## Summary
- keep preview change sets in interactive mode long enough to support an immediate deploy decision instead of always deleting them first
- when the user confirms deploy, execute the same reviewed change set ARN with ownership/status checks (`StackId` match and `CREATE_COMPLETE`/`AVAILABLE`) before execution
- preserve safe cleanup behavior when deploy is declined (delete preview change set, then cleanup preview-only `REVIEW_IN_PROGRESS` stack when applicable)
- expose reusable CloudFormation helpers to execute an existing change set and inspect/delete preview change sets

## Test plan
- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run build`