### PR TITLE
fix: use -c shorthand for update-stack --create

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ awscfn update-stack -n <STACK_NAME> -t <TEMPLATE_FILE> -p <PARAMS_FILE>
 | `--params`, `-p` | Parameters file (YAML) |
 | `--set`, `-s` | Override one or more parameters (repeatable `Key=Value`). You can omit `--params` to override only specific values on an existing stack. |
 | `--create` | If the stack doesn't exist, create it (instead of erroring) |
-| `-m` | Shorthand for `--create` |
+| `-c` | Shorthand for `--create` |
 
 If there are no changes to apply, the command succeeds gracefully:
 ```

--- a/bin/awscfn
+++ b/bin/awscfn
@@ -326,7 +326,7 @@ const setOpt = {
 const createIfMissingOpt = {
   create: {
     type: 'boolean',
-    alias: 'm',
+    alias: 'c',
     describe: 'Create the stack if it does not exist (update-stack only)',
     demandOption: false,
     default: false,


### PR DESCRIPTION
## Summary
- change `update-stack` create shorthand from `-m` to `-c` in the CLI option definition
- update `README.md` command docs so the shorthand shown for `--create` matches the CLI behavior
- keep `delete-stack -c/--confirm` unchanged (command-local option)

## Test plan
- [x] `npm test`
- [x] `node bin/awscfn update-stack --help` shows `-c, --create`
- [x] `node bin/awscfn delete-stack --help` still shows `-c, --confirm`